### PR TITLE
Add precomputed brand dark grey light variable

### DIFF
--- a/src/Resources/app/storefront/src/scss/_buttons.scss
+++ b/src/Resources/app/storefront/src/scss/_buttons.scss
@@ -32,7 +32,7 @@ button,
 .sw-btn--secondary {
     border-radius: #{$btn-radius}px;
     background: transparent;
-    border: 1px solid lighten($brand-dark-grey, 18%);
+    border: 1px solid $brand-dark-grey-light;
     color: #e5f7ee;
 
     &:hover {

--- a/src/Resources/app/storefront/src/scss/_variables.scss
+++ b/src/Resources/app/storefront/src/scss/_variables.scss
@@ -2,6 +2,7 @@
 $brand-primary: theme-color("brandPrimary", #51d88a);
 $brand-primary-dark: theme-color("brandPrimaryDark", #38b26f);
 $brand-dark-grey: theme-color("brandDarkGrey", #1f2933);
+$brand-dark-grey-light: lighten(#1f2933, 18%);
 $btn-radius: to-number(theme-value("buttonRadiusPx", 6));
 
 // Helper: convert string to number (Shopware passes config as string)


### PR DESCRIPTION
## Summary
- add a precomputed `$brand-dark-grey-light` color token alongside the existing theme variables
- update the secondary button border to reuse the shared light grey token

## Testing
- `npx sass src/Resources/app/storefront/src/scss/base.scss /tmp/base.css` *(fails: npm registry access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c95039369c83299fc8df73e9bbb99d