### PR TITLE
Add precomputed light brand color variable and use for link hover

### DIFF
--- a/src/Resources/app/storefront/src/scss/_overrides.scss
+++ b/src/Resources/app/storefront/src/scss/_overrides.scss
@@ -21,7 +21,7 @@ a {
     color: $brand-primary;
 
     &:hover {
-        color: lighten($brand-primary, 6%);
+        color: $brand-primary-light;
     }
 }
 

--- a/src/Resources/app/storefront/src/scss/_variables.scss
+++ b/src/Resources/app/storefront/src/scss/_variables.scss
@@ -1,6 +1,7 @@
 // Theme configuration values from the administration
 $brand-primary: theme-color("brandPrimary", #51d88a);
 $brand-primary-dark: theme-color("brandPrimaryDark", #38b26f);
+$brand-primary-light: #69dd9a; // precomputed 6% lightened #51d88a
 $brand-dark-grey: theme-color("brandDarkGrey", #1f2933);
 $brand-dark-grey-light: lighten(#1f2933, 18%);
 $btn-radius: to-number(theme-value("buttonRadiusPx", 6));


### PR DESCRIPTION
## Summary
- add a precomputed light variant of the brand primary color
- update link hover styling to use the new precomputed color

## Testing
- bin/console theme:compile *(fails: `bin/console` not found in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c96c718038832996c1e379d95f9477