### PR TITLE
Precompute brand dark grey light variable

### DIFF
--- a/src/Resources/app/storefront/src/scss/_variables.scss
+++ b/src/Resources/app/storefront/src/scss/_variables.scss
@@ -3,7 +3,7 @@ $brand-primary: theme-color("brandPrimary", #51d88a);
 $brand-primary-dark: theme-color("brandPrimaryDark", #38b26f);
 $brand-primary-light: #69dd9a; // precomputed 6% lightened #51d88a
 $brand-dark-grey: theme-color("brandDarkGrey", #1f2933);
-$brand-dark-grey-light: lighten(#1f2933, 18%);
+$brand-dark-grey-light: #41566c; // 18% lightened #1f2933
 $btn-radius: to-number(theme-value("buttonRadiusPx", 6));
 $font-family-base: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif !default;
 


### PR DESCRIPTION
## Summary
- replace the computed brand dark grey light variable with the precomputed #41566c constant

## Testing
- `bin/console theme:compile` *(fails: command not found in this repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c97156e96483299e9c585bb50dc4cb