### PR TITLE
Use static theme variables

### DIFF
--- a/src/Resources/app/storefront/src/scss/_variables.scss
+++ b/src/Resources/app/storefront/src/scss/_variables.scss
@@ -1,10 +1,10 @@
 // Theme configuration values from the administration
-$brand-primary: theme-color("brandPrimary", #51d88a);
-$brand-primary-dark: theme-color("brandPrimaryDark", #38b26f);
+$brand-primary: #51d88a;
+$brand-primary-dark: #38b26f;
 $brand-primary-light: #69dd9a; // precomputed 6% lightened #51d88a
-$brand-dark-grey: theme-color("brandDarkGrey", #1f2933);
+$brand-dark-grey: #1f2933;
 $brand-dark-grey-light: lighten(#1f2933, 18%);
-$btn-radius: to-number(theme-value("buttonRadiusPx", 6));
+$btn-radius: 6px;
 $font-family-base: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif !default;
 
 // Helper: convert string to number (Shopware passes config as string)


### PR DESCRIPTION
## Summary
- replace theme color helper calls with hard-coded primary and dark grey values
- set the button radius variable to a static pixel value

## Testing
- bin/console theme:compile *(fails: `bin/console` not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c97159ff008329bfbf99a35fa03955