### PR TITLE
Import parent base styles before overrides

### DIFF
--- a/src/Resources/app/storefront/src/scss/base.scss
+++ b/src/Resources/app/storefront/src/scss/base.scss
@@ -1,3 +1,5 @@
+@import "~Storefront/Resources/app/storefront/src/scss/variables";
 @import "./variables";
+@import "~Storefront/Resources/app/storefront/src/scss/base";
 @import "./buttons";
 @import "./overrides";


### PR DESCRIPTION
## Summary
- import the parent storefront SCSS variables and base styles before local overrides

## Testing
- not run (Shopware CLI not available in this repository)


------
https://chatgpt.com/codex/tasks/task_e_68c973ddf3848329887c9fcf61f0f1a9