### PR TITLE
Extract homepage styles into SCSS

### DIFF
--- a/src/Resources/app/storefront/src/scss/base.scss
+++ b/src/Resources/app/storefront/src/scss/base.scss
@@ -3,3 +3,4 @@
 @import "~Storefront/Resources/app/storefront/src/scss/base";
 @import "./buttons";
 @import "./overrides";
+@import "./home";

--- a/src/Resources/app/storefront/src/scss/home.scss
+++ b/src/Resources/app/storefront/src/scss/home.scss
@@ -1,0 +1,84 @@
+.sk-hero,
+.sk-features,
+.sk-cta {
+  &.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+  }
+}
+
+.sk-hero {
+  padding: 6rem 0;
+  background: linear-gradient(135deg, var(--brand-dark-grey), #0b1117);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+
+  &__title {
+    font-size: 3rem;
+    line-height: 1.1;
+    margin: 0 0 0.75rem;
+    font-weight: 800;
+
+    span {
+      background: linear-gradient(
+        135deg,
+        var(--brand-primary),
+        var(--brand-primary-dark)
+      );
+      -webkit-background-clip: text;
+      background-clip: text;
+      color: transparent;
+    }
+  }
+
+  &__lead {
+    opacity: 0.9;
+    max-width: 48ch;
+    margin: 0 0 1.5rem;
+  }
+
+  &__cta {
+    .btn {
+      margin-right: 0.75rem;
+    }
+  }
+}
+
+.sk-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+}
+
+.sk-card {
+  background: #111827;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 1.25rem;
+
+  h3 {
+    margin: 0.25rem 0 0.5rem;
+  }
+}
+
+.sk-cta {
+  padding: 3rem 0;
+
+  &__box {
+    background: #0f1720;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 14px;
+    padding: 2rem;
+    text-align: center;
+  }
+}
+
+@media (max-width: 980px) {
+  .sk-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sk-hero__title {
+    font-size: 2.4rem;
+  }
+}

--- a/src/Resources/views/storefront/page/content/index.html.twig
+++ b/src/Resources/views/storefront/page/content/index.html.twig
@@ -48,20 +48,6 @@ Starte jetzt mit unseren Favoriten.</p>
 </section>
 
 
-<style>
-.container{max-width:1200px;margin:0 auto;padding:2rem;}
-.sk-hero{padding:6rem 0;background:linear-gradient(135deg,var(--brand-dark-grey),#0b1117);border-bottom:1px solid rgba(255,255,255,.06)}
-.sk-hero__title{font-size:3rem;line-height:1.1;margin:0 0 .75rem;font-weight:800}
-.sk-hero__title span{background:linear-gradient(135deg,var(--brand-primary),var(--brand-primary-dark));-webkit-background-clip:text;background-clip:text;color:transparent}
-.sk-hero__lead{opacity:.9;max-width:48ch;margin:0 0 1.5rem}
-.sk-hero__cta .btn{margin-right:.75rem}
-.sk-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.25rem}
-.sk-card{background:#111827;border:1px solid rgba(255,255,255,.06);border-radius:12px;padding:1.25rem}
-.sk-card h3{margin:.25rem 0 .5rem}
-.sk-cta{padding:3rem 0}
-.sk-cta__box{background:#0f1720;border:1px solid rgba(255,255,255,.06);border-radius:14px;padding:2rem;text-align:center}
-@media (max-width: 980px){.sk-grid{grid-template-columns:1fr}.sk-hero__title{font-size:2.4rem}}
-</style>
 {% else %}
 {{ parent() }}
 {% endif %}


### PR DESCRIPTION
## Summary
- move the homepage hero and CTA styling into a dedicated `home.scss`
- register the new stylesheet in the theme's base bundle
- drop the inline `<style>` block from the homepage override so it uses the compiled assets

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68c9754c5e5083299e35bb5ac9b1da44