### PR TITLE
Use Shopware alias for variables import

### DIFF
--- a/src/Resources/app/storefront/src/scss/base.scss
+++ b/src/Resources/app/storefront/src/scss/base.scss
@@ -1,4 +1,4 @@
-@import "~Storefront/Resources/app/storefront/src/scss/variables";
+@import "@Storefront/Resources/app/storefront/src/scss/variables";
 @import "./variables";
 @import "~Storefront/Resources/app/storefront/src/scss/base";
 @import "./buttons";


### PR DESCRIPTION
## Summary
- replace the deprecated `~Storefront` alias in the variables import with the Shopware 6.5 `@Storefront` alias so the stylesheet resolves correctly

## Testing
- bin/console theme:compile *(fails: `bin/console` not present in this isolated plugin repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b6a4e9c8832994b3af20e252f5e4