### PR TITLE
Limit Shopware core requirement to ^6.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,6 @@
     }
   },
   "require": {
-    "shopware/core": ">=6.5.0"
+    "shopware/core": "^6.5"
   }
 }


### PR DESCRIPTION
## Summary
- limit the shopware/core dependency to the ^6.5 release line in composer.json to avoid future incompatible updates

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68c9b76bc9508329ab8be726680887ba