### PR TITLE
Fix button border radius variable usage

### DIFF
--- a/src/Resources/app/storefront/src/scss/_buttons.scss
+++ b/src/Resources/app/storefront/src/scss/_buttons.scss
@@ -4,7 +4,7 @@
 .btn-buy,
 button,
 .sw-btn {
-    border-radius: #{$btn-radius}px;
+    border-radius: $btn-radius;
     border: 1px solid rgba(0, 0, 0, 0.18);
     background-image: linear-gradient(135deg, $brand-primary 0%, $brand-primary-dark 100%);
     color: $brand-primary-contrast;
@@ -30,7 +30,7 @@ button,
 // Secondary / outline variant for dark grey theme
 .btn-outline,
 .sw-btn--secondary {
-    border-radius: #{$btn-radius}px;
+    border-radius: $btn-radius;
     background: transparent;
     border: 1px solid $brand-dark-grey-light;
     color: #e5f7ee;


### PR DESCRIPTION
## Summary
- adjust button styles to use the raw SCSS radius variable so the configured value is emitted correctly for primary and outline buttons

## Testing
- bin/console theme:compile *(fails: bin/console not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cc05b2e48329962c51efe8564dd2