### PR TITLE
Fix hero section container selector

### DIFF
--- a/src/Resources/app/storefront/src/scss/home.scss
+++ b/src/Resources/app/storefront/src/scss/home.scss
@@ -1,7 +1,7 @@
 .sk-hero,
 .sk-features,
 .sk-cta {
-  &.container {
+  .container {
     max-width: 1200px;
     margin: 0 auto;
     padding: 2rem;


### PR DESCRIPTION
## Summary
- target the child `.container` within the hero, features, and CTA sections so their shared max-width and spacing apply correctly

## Testing
- bin/console theme:compile *(fails: bin/console: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cc6ffcec8329a4300602f6bdd558