### PR TITLE
Register parent storefront styles in theme

### DIFF
--- a/src/Resources/app/storefront/src/scss/base.scss
+++ b/src/Resources/app/storefront/src/scss/base.scss
@@ -1,6 +1,5 @@
 @import "@Storefront/Resources/app/storefront/src/scss/variables";
 @import "./variables";
-@import "~Storefront/Resources/app/storefront/src/scss/base";
 @import "./buttons";
 @import "./overrides";
 @import "./home";

--- a/src/Resources/theme.json
+++ b/src/Resources/theme.json
@@ -7,6 +7,7 @@
     "Resources/views"
   ],
   "style": [
+    "@Storefront",
     "app/storefront/src/scss/base.scss"
   ],
   "script": [


### PR DESCRIPTION
## Summary
- register the Storefront SCSS bundle in the theme style array so the parent assets build automatically
- remove the manual Storefront base import from the custom SCSS entrypoint now that the bundle is registered

## Testing
- `bin/console theme:compile` *(fails: bin/console missing in isolated theme repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ce48284c83299388e36fe37b7c80