### PR TITLE
Adopt bright Divi styling for Skylad theme

### DIFF
--- a/src/Resources/app/storefront/src/scss/_buttons.scss
+++ b/src/Resources/app/storefront/src/scss/_buttons.scss
@@ -1,41 +1,91 @@
-// Base button styling with gradient + border + radius
+// Divi-inspired base button styling
 .btn,
 .btn-primary,
 .btn-buy,
 button,
 .sw-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    padding: 0.75rem 1.75rem;
     border-radius: $btn-radius;
-    border: 1px solid rgba(0, 0, 0, 0.18);
-    background-image: linear-gradient(135deg, $brand-primary 0%, $brand-primary-dark 100%);
+    border: 1px solid transparent;
+    background: $brand-primary;
     color: $brand-primary-contrast;
     font-weight: 600;
-    transition: transform 0.06s ease, box-shadow 0.2s ease, filter 0.2s ease;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    text-decoration: none;
+    box-shadow: 0 16px 32px rgba($brand-primary, 0.18);
+    transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.12s ease;
 
-    &:hover {
-        filter: brightness(1.02) saturate(1.05);
+    &:hover,
+    &:focus {
+        background: $brand-primary-dark;
+        color: $brand-primary-contrast;
+        box-shadow: 0 20px 36px rgba($brand-primary, 0.22);
         transform: translateY(-1px);
-        box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+    }
+
+    &:focus {
+        outline: none;
+        box-shadow: 0 0 0 3px rgba($brand-primary, 0.35);
     }
 
     &:active {
         transform: translateY(0);
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18) inset;
+        box-shadow: 0 8px 18px rgba($brand-primary, 0.18);
+    }
+
+    &:disabled,
+    &.is-disabled {
+        background: lighten($brand-primary, 18%);
+        color: rgba($brand-primary-contrast, 0.65);
+        box-shadow: none;
+        cursor: not-allowed;
+        transform: none;
     }
 
     &.btn--clicked {
-        outline: 2px solid rgba(255, 255, 255, 0.25);
+        box-shadow: 0 0 0 3px rgba($brand-primary, 0.25);
     }
 }
 
-// Secondary / outline variant for dark grey theme
+// Secondary / outline variant for optional contrast usage
 .btn-outline,
-.sw-btn--secondary {
+.btn-secondary,
+.sw-btn--secondary,
+.btn-outline-primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    padding: 0.75rem 1.75rem;
     border-radius: $btn-radius;
     background: transparent;
-    border: 1px solid $brand-dark-grey-light;
-    color: #e5f7ee;
+    border: 2px solid $brand-primary;
+    color: $brand-primary;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.12s ease;
 
-    &:hover {
-        background: rgba(255, 255, 255, 0.04);
+    &:hover,
+    &:focus {
+        background: rgba($brand-primary, 0.08);
+        color: $brand-primary-dark;
+        border-color: $brand-primary-dark;
+        transform: translateY(-1px);
+    }
+
+    &:focus {
+        outline: none;
+        box-shadow: 0 0 0 3px rgba($brand-primary, 0.2);
+    }
+
+    &:active {
+        transform: translateY(0);
+        background: rgba($brand-primary, 0.12);
     }
 }

--- a/src/Resources/app/storefront/src/scss/_overrides.scss
+++ b/src/Resources/app/storefront/src/scss/_overrides.scss
@@ -9,34 +9,115 @@ Adjust global colors, typography and small layout tweaks for the Skylad theme.
     --brand-primary: #{$brand-primary};
     --brand-primary-dark: #{$brand-primary-dark};
     --brand-dark-grey: #{$brand-dark-grey};
+    --text-color: #{$text-color};
+    --text-color-muted: #{$text-color-muted};
+    --surface-bg: #{$surface-bg};
+    --surface-muted: #{$surface-muted};
 }
 
 body {
     background: $surface-bg;
-    color: #e6f6ee;
+    color: $text-color;
     font-family: $font-family-base;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
 }
 
 a {
     color: $brand-primary;
+    text-decoration: none;
+    transition: color 0.2s ease, box-shadow 0.2s ease;
 
-    &:hover {
-        color: $brand-primary-light;
+    &:hover,
+    &:focus {
+        color: $brand-primary-dark;
     }
 }
 
-// Links in dark header/footer
-.header-main,
-.footer-main {
-    background: $brand-dark-grey;
+// Header + footer styling inspired by Divi
+.header-top {
+    background: $surface-muted;
+    color: $text-color-muted;
+    font-size: 0.8125rem;
+    padding: 0.35rem 0;
+
+    a {
+        color: $brand-primary;
+
+        &:hover,
+        &:focus {
+            color: $brand-primary-dark;
+        }
+    }
 }
 
-// Topbar banner that can be toggled via CMS block
+.header-main {
+    background: $surface-bg;
+    color: $text-color;
+    border-bottom: 1px solid rgba($text-color, 0.08);
+    box-shadow: 0 8px 24px rgba($text-color, 0.04);
+
+    a {
+        color: inherit;
+
+        &:hover,
+        &:focus {
+            color: $brand-primary;
+        }
+    }
+}
+
+.footer-main {
+    background: $surface-muted;
+    color: $text-color;
+    border-top: 1px solid rgba($text-color, 0.08);
+
+    a {
+        color: $brand-primary;
+
+        &:hover,
+        &:focus {
+            color: $brand-primary-dark;
+        }
+    }
+}
+
+// Optional topbar banner for announcements
 .skylad-topbar {
     display: block;
     background: $brand-primary;
-    color: #fff;
+    color: $brand-primary-contrast;
     font-size: 0.875rem;
+    font-weight: 600;
     padding: 0.375rem 0.75rem;
     text-align: center;
+}
+
+// Helper surfaces for darker sections
+.surface-contrast {
+    background: $surface-contrast;
+    color: $surface-contrast-text;
+
+    a {
+        color: $brand-primary-light;
+
+        &:hover,
+        &:focus {
+            color: lighten($brand-primary-light, 6%);
+        }
+    }
+}
+
+.surface-contrast--muted {
+    background: $surface-contrast-muted;
+    color: $surface-contrast-text;
+
+    a {
+        color: $brand-primary-light;
+
+        &:hover,
+        &:focus {
+            color: lighten($brand-primary-light, 6%);
+        }
+    }
 }

--- a/src/Resources/app/storefront/src/scss/_variables.scss
+++ b/src/Resources/app/storefront/src/scss/_variables.scss
@@ -1,11 +1,15 @@
 // Theme configuration values from the administration
-$brand-primary: #51d88a;
-$brand-primary-dark: #38b26f;
-$brand-primary-light: #69dd9a; // precomputed 6% lightened #51d88a
+$brand-primary: #2ea3f2;
+$brand-primary-dark: #1f7bb8;
+$brand-primary-light: #5cc3f5; // precomputed 12% lightened #2ea3f2
 $brand-dark-grey: #1f2933;
 $btn-radius: 6px;
-$brand-dark-grey-light: #41566c; // 18% lightened #1f2933
-$font-family-base: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif !default;
+$brand-dark-grey-light: #334155; // softened accent for optional dark sections
+$font-family-base: 'Open Sans', 'Helvetica Neue', Arial, sans-serif !default;
+
+// Base typography colors
+$text-color: #1f2933;
+$text-color-muted: #4b5563;
 
 // Helper: convert string to number (Shopware passes config as string)
 @function to-number($value, $fallback: 0) {
@@ -13,6 +17,12 @@ $font-family-base: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif !defa
 }
 
 // Derived palette
-$brand-primary-contrast: #0f1720; // very dark for contrast on light green backgrounds
-$surface-bg: #0b0f14; // near-black background accents
-$surface-muted: #111827; // dark grey surfaces
+$brand-primary-contrast: #ffffff;
+$surface-bg: #ffffff;
+$surface-muted: #f5f8fb; // pale neutral section background
+$surface-subtle: #eef2f7; // alternative light striping option
+
+// Additional helper colors for dark sections when still required
+$surface-contrast: #0f172a;
+$surface-contrast-muted: #16233a;
+$surface-contrast-text: #f8fafc;

--- a/src/Resources/theme.json
+++ b/src/Resources/theme.json
@@ -20,26 +20,35 @@
     "fields": {
       "brandPrimary": {
         "label": {
-          "en-GB": "Primary (Light Green)",
-          "de-DE": "Primärfarbe (Hellgrün)"
+          "en-GB": "Primary (Divi Blue)",
+          "de-DE": "Primärfarbe (Divi-Blau)"
         },
         "type": "color",
         "editable": true,
-        "value": "#51d88a"
+        "value": "#2ea3f2"
       },
       "brandPrimaryDark": {
         "label": {
-          "en-GB": "Primary Dark",
-          "de-DE": "Primär dunkel"
+          "en-GB": "Primary Dark (Hover)",
+          "de-DE": "Primär dunkel (Hover)"
         },
         "type": "color",
         "editable": true,
-        "value": "#38b26f"
+        "value": "#1f7bb8"
       },
       "brandDarkGrey": {
         "label": {
           "en-GB": "Dark Grey",
           "de-DE": "Dunkelgrau"
+        },
+        "type": "color",
+        "editable": true,
+        "value": "#1f2933"
+      },
+      "textColor": {
+        "label": {
+          "en-GB": "Text color",
+          "de-DE": "Textfarbe"
         },
         "type": "color",
         "editable": true,


### PR DESCRIPTION
## Summary
- align the variable palette with a bright Divi-inspired blue theme including new helper colors and typography defaults
- refresh global overrides for light body styling, Divi-like header/footer treatments, and optional contrast surface helpers
- restyle primary and outline buttons with flat blue Divi aesthetics and expose updated primary/text colors in the admin theme config

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9d8a66c1883299dacc7c5193a6ed5