### PR TITLE
Rebuild homepage to mirror Divi repair layout

### DIFF
--- a/src/Resources/app/storefront/src/assets/highlight-delivery.svg
+++ b/src/Resources/app/storefront/src/assets/highlight-delivery.svg
@@ -1,0 +1,31 @@
+<svg width="640" height="480" viewBox="0 0 640 480" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="panel" x1="0" y1="0" x2="640" y2="480" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F3F8FF"/>
+      <stop offset="1" stop-color="#E2F1FF"/>
+    </linearGradient>
+    <linearGradient id="van" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#FFFFFF"/>
+      <stop offset="1" stop-color="#EDF4FF"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" rx="40" fill="url(#panel)"/>
+  <g transform="translate(120 140)">
+    <rect x="0" y="64" width="400" height="132" rx="38" fill="#2EA3F2" fill-opacity="0.08"/>
+    <path d="M84 60H250C274 60 294 80 294 104V164H126C102 164 84 146 84 122V60Z" fill="url(#van)" stroke="#D1E3F8" stroke-width="6"/>
+    <path d="M294 104C294 79.1472 314.147 59 339 59H360C383.196 59 402 77.804 402 101V164H294V104Z" fill="#FFFFFF" stroke="#D1E3F8" stroke-width="6"/>
+    <rect x="120" y="96" width="104" height="44" rx="16" fill="#2EA3F2" fill-opacity="0.12"/>
+    <rect x="246" y="98" width="44" height="40" rx="14" fill="#2EA3F2" fill-opacity="0.14"/>
+    <circle cx="150" cy="170" r="28" fill="#FFFFFF" stroke="#2EA3F2" stroke-width="6"/>
+    <circle cx="306" cy="170" r="28" fill="#FFFFFF" stroke="#2EA3F2" stroke-width="6"/>
+    <circle cx="150" cy="170" r="12" fill="#2EA3F2" fill-opacity="0.6"/>
+    <circle cx="306" cy="170" r="12" fill="#2EA3F2" fill-opacity="0.6"/>
+    <path d="M36 140H96" stroke="#BFD6F3" stroke-width="8" stroke-linecap="round"/>
+    <path d="M22 116H76" stroke="#BFD6F3" stroke-width="8" stroke-linecap="round"/>
+  </g>
+  <g transform="translate(416 86)">
+    <rect x="0" y="0" width="128" height="128" rx="30" fill="#FFFFFF" stroke="#D1E3F8" stroke-width="5"/>
+    <path d="M36 86L62 40L90 86H36Z" fill="#2EA3F2" fill-opacity="0.12" stroke="#2EA3F2" stroke-width="4" stroke-linejoin="round"/>
+    <path d="M78 46C84.6274 46 90 40.6274 90 34C90 27.3726 84.6274 22 78 22C71.3726 22 66 27.3726 66 34C66 40.6274 71.3726 46 78 46Z" fill="#2EA3F2" fill-opacity="0.16"/>
+  </g>
+</svg>

--- a/src/Resources/app/storefront/src/assets/highlight-service.svg
+++ b/src/Resources/app/storefront/src/assets/highlight-service.svg
@@ -1,0 +1,23 @@
+<svg width="640" height="480" viewBox="0 0 640 480" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="card-bg" x1="0" y1="0" x2="640" y2="480" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F4F9FF"/>
+      <stop offset="1" stop-color="#E6F2FF"/>
+    </linearGradient>
+    <linearGradient id="screen" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#FFFFFF"/>
+      <stop offset="1" stop-color="#ECF3FF"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" rx="40" fill="url(#card-bg)"/>
+  <rect x="120" y="96" width="400" height="248" rx="28" fill="url(#screen)" stroke="#D3E3F8" stroke-width="6"/>
+  <rect x="162" y="140" width="316" height="72" rx="20" fill="#2EA3F2" fill-opacity="0.1"/>
+  <rect x="162" y="228" width="316" height="44" rx="14" fill="#2EA3F2" fill-opacity="0.12"/>
+  <rect x="162" y="284" width="180" height="36" rx="12" fill="#2EA3F2" fill-opacity="0.16"/>
+  <circle cx="320" cy="370" r="24" fill="#2EA3F2" fill-opacity="0.16"/>
+  <path d="M320 356C311.716 356 305 362.716 305 371C305 379.284 311.716 386 320 386C328.284 386 335 379.284 335 371C335 362.716 328.284 356 320 356ZM316.5 379.5L309.5 372.5L311.914 370.086L316.5 374.672L328.086 363.086L330.5 365.5L316.5 379.5Z" fill="#2EA3F2"/>
+  <g opacity="0.9" transform="translate(420 52)">
+    <rect x="0" y="0" width="120" height="120" rx="26" fill="#FFFFFF" stroke="#D3E3F8" stroke-width="5"/>
+    <path d="M60 28C45.6406 28 34 39.6406 34 54C34 70 60 98 60 98C60 98 86 70 86 54C86 39.6406 74.3594 28 60 28ZM60 66.5C53.6487 66.5 48.5 61.3513 48.5 55C48.5 48.6487 53.6487 43.5 60 43.5C66.3513 43.5 71.5 48.6487 71.5 55C71.5 61.3513 66.3513 66.5 60 66.5Z" fill="#2EA3F2" fill-opacity="0.2"/>
+  </g>
+</svg>

--- a/src/Resources/app/storefront/src/assets/slider-hero-01.svg
+++ b/src/Resources/app/storefront/src/assets/slider-hero-01.svg
@@ -1,22 +1,43 @@
 <svg width="1920" height="960" viewBox="0 0 1920 960" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="1920" height="960" fill="url(#paint0_linear)"/>
-  <g opacity="0.3">
-    <circle cx="340" cy="180" r="220" fill="url(#paint1_radial)"/>
-    <circle cx="1660" cy="780" r="260" fill="url(#paint2_radial)"/>
-  </g>
-  <path opacity="0.12" d="M1920 230C1540 420 1350 540 960 540C570 540 380 420 0 230V960H1920V230Z" fill="#FFFFFF"/>
   <defs>
-    <linearGradient id="paint0_linear" x1="0" y1="0" x2="1920" y2="960" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#050912"/>
-      <stop offset="1" stop-color="#0B1F2A"/>
+    <linearGradient id="bgGradient" x1="0" y1="0" x2="1920" y2="960" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F7FBFF"/>
+      <stop offset="1" stop-color="#DCEBFF"/>
     </linearGradient>
-    <radialGradient id="paint1_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(340 180) rotate(90) scale(220)">
-      <stop stop-color="#57F2BC" stop-opacity="0.7"/>
-      <stop offset="1" stop-color="#57F2BC" stop-opacity="0"/>
+    <radialGradient id="spotOne" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse"
+      gradientTransform="translate(480 240) rotate(90) scale(320)">
+      <stop offset="0" stop-color="#2EA3F2" stop-opacity="0.45"/>
+      <stop offset="1" stop-color="#2EA3F2" stop-opacity="0"/>
     </radialGradient>
-    <radialGradient id="paint2_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1660 780) rotate(90) scale(260)">
-      <stop stop-color="#50C4F2" stop-opacity="0.6"/>
-      <stop offset="1" stop-color="#50C4F2" stop-opacity="0"/>
+    <radialGradient id="spotTwo" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse"
+      gradientTransform="translate(1520 720) rotate(90) scale(360)">
+      <stop offset="0" stop-color="#6BC7FF" stop-opacity="0.35"/>
+      <stop offset="1" stop-color="#6BC7FF" stop-opacity="0"/>
     </radialGradient>
+    <linearGradient id="phoneBody" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#FFFFFF"/>
+      <stop offset="1" stop-color="#F0F6FF"/>
+    </linearGradient>
+    <linearGradient id="shadow" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#D1E5FF" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0"/>
+    </linearGradient>
   </defs>
+  <rect width="1920" height="960" fill="url(#bgGradient)"/>
+  <circle cx="460" cy="240" r="320" fill="url(#spotOne)"/>
+  <circle cx="1500" cy="680" r="360" fill="url(#spotTwo)"/>
+  <path d="M0 720C320 620 640 580 960 600C1280 620 1600 700 1920 760V960H0V720Z" fill="url(#shadow)"/>
+  <g transform="translate(1080 140)">
+    <rect x="60" y="40" width="280" height="560" rx="40" fill="url(#phoneBody)" stroke="#D1E4FF" stroke-width="8"/>
+    <rect x="120" y="110" width="160" height="300" rx="24" fill="#2EA3F2" fill-opacity="0.12"/>
+    <rect x="120" y="430" width="160" height="68" rx="16" fill="#2EA3F2" fill-opacity="0.18"/>
+    <circle cx="200" cy="82" r="8" fill="#CDDFFD"/>
+    <rect x="180" y="520" width="40" height="12" rx="6" fill="#CDDFFD"/>
+  </g>
+  <g transform="translate(1370 240) rotate(10)">
+    <rect x="0" y="0" width="200" height="360" rx="34" fill="#FFFFFF" stroke="#D1E4FF" stroke-width="6"/>
+    <rect x="36" y="76" width="128" height="120" rx="18" fill="#2EA3F2" fill-opacity="0.1"/>
+    <rect x="36" y="220" width="128" height="52" rx="14" fill="#2EA3F2" fill-opacity="0.16"/>
+    <circle cx="100" cy="44" r="6" fill="#D7E7FF"/>
+  </g>
 </svg>

--- a/src/Resources/app/storefront/src/assets/slider-hero-02.svg
+++ b/src/Resources/app/storefront/src/assets/slider-hero-02.svg
@@ -1,22 +1,48 @@
 <svg width="1920" height="960" viewBox="0 0 1920 960" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="1920" height="960" fill="url(#paint0_linear)"/>
-  <g opacity="0.35">
-    <circle cx="1540" cy="200" r="260" fill="url(#paint1_radial)"/>
-    <circle cx="460" cy="720" r="240" fill="url(#paint2_radial)"/>
-  </g>
-  <path opacity="0.16" d="M0 120C320 360 640 480 960 480C1280 480 1600 360 1920 120V960H0V120Z" fill="#FFFFFF"/>
   <defs>
-    <linearGradient id="paint0_linear" x1="120" y1="-48" x2="1740" y2="1035" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#070F1A"/>
-      <stop offset="1" stop-color="#102A3C"/>
+    <linearGradient id="bgGradient02" x1="120" y1="80" x2="1800" y2="880" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F2F8FF"/>
+      <stop offset="1" stop-color="#E3F2FF"/>
     </linearGradient>
-    <radialGradient id="paint1_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1540 200) rotate(90) scale(260)">
-      <stop stop-color="#7EF2D4" stop-opacity="0.6"/>
-      <stop offset="1" stop-color="#7EF2D4" stop-opacity="0"/>
+    <radialGradient id="spotA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse"
+      gradientTransform="translate(1520 260) rotate(90) scale(340)">
+      <stop offset="0" stop-color="#2EA3F2" stop-opacity="0.4"/>
+      <stop offset="1" stop-color="#2EA3F2" stop-opacity="0"/>
     </radialGradient>
-    <radialGradient id="paint2_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(460 720) rotate(90) scale(240)">
-      <stop stop-color="#4EB5FF" stop-opacity="0.55"/>
-      <stop offset="1" stop-color="#4EB5FF" stop-opacity="0"/>
+    <radialGradient id="spotB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse"
+      gradientTransform="translate(420 700) rotate(90) scale(300)">
+      <stop offset="0" stop-color="#8FD6FF" stop-opacity="0.32"/>
+      <stop offset="1" stop-color="#8FD6FF" stop-opacity="0"/>
     </radialGradient>
+    <linearGradient id="monitor" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#FFFFFF"/>
+      <stop offset="1" stop-color="#EBF3FF"/>
+    </linearGradient>
+    <linearGradient id="keyboard" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#DCE8F8"/>
+      <stop offset="1" stop-color="#FFFFFF"/>
+    </linearGradient>
   </defs>
+  <rect width="1920" height="960" fill="url(#bgGradient02)"/>
+  <circle cx="1490" cy="280" r="340" fill="url(#spotA)"/>
+  <circle cx="440" cy="700" r="300" fill="url(#spotB)"/>
+  <path d="M0 660C240 560 540 520 960 540C1380 560 1680 620 1920 700V960H0V660Z" fill="#D7E7FB" fill-opacity="0.45"/>
+  <g transform="translate(1080 220)">
+    <rect x="0" y="0" width="420" height="260" rx="28" fill="url(#monitor)" stroke="#D5E4FB" stroke-width="8"/>
+    <rect x="40" y="46" width="340" height="172" rx="20" fill="#2EA3F2" fill-opacity="0.12"/>
+    <rect x="184" y="12" width="52" height="12" rx="6" fill="#C8DAF5"/>
+    <rect x="90" y="230" width="240" height="12" rx="6" fill="#C6DAF7"/>
+  </g>
+  <g transform="translate(1160 490)">
+    <path d="M0 0H340L320 70H20L0 0Z" fill="url(#keyboard)" stroke="#D5E4FB" stroke-width="6"/>
+    <rect x="40" y="20" width="80" height="18" rx="8" fill="#D9E8FC"/>
+    <rect x="132" y="20" width="80" height="18" rx="8" fill="#D9E8FC"/>
+    <rect x="224" y="20" width="80" height="18" rx="8" fill="#D9E8FC"/>
+  </g>
+  <g transform="translate(1380 170) rotate(-8)">
+    <rect x="0" y="0" width="180" height="320" rx="28" fill="#FFFFFF" stroke="#D5E4FB" stroke-width="6"/>
+    <rect x="36" y="64" width="108" height="180" rx="18" fill="#2EA3F2" fill-opacity="0.1"/>
+    <rect x="36" y="258" width="108" height="40" rx="12" fill="#2EA3F2" fill-opacity="0.18"/>
+    <circle cx="90" cy="36" r="6" fill="#D9E7FC"/>
+  </g>
 </svg>

--- a/src/Resources/app/storefront/src/assets/slider-hero-03.svg
+++ b/src/Resources/app/storefront/src/assets/slider-hero-03.svg
@@ -1,22 +1,44 @@
 <svg width="1920" height="960" viewBox="0 0 1920 960" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="1920" height="960" fill="url(#paint0_linear)"/>
-  <g opacity="0.35">
-    <circle cx="320" cy="640" r="280" fill="url(#paint1_radial)"/>
-    <circle cx="1580" cy="320" r="220" fill="url(#paint2_radial)"/>
-  </g>
-  <path opacity="0.14" d="M0 750C320 620 640 560 960 560C1280 560 1600 620 1920 750V960H0V750Z" fill="#FFFFFF"/>
   <defs>
-    <linearGradient id="paint0_linear" x1="0" y1="0" x2="1920" y2="960" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#081018"/>
-      <stop offset="1" stop-color="#0D2330"/>
+    <linearGradient id="bgGradient03" x1="0" y1="0" x2="1920" y2="920" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F9FCFF"/>
+      <stop offset="1" stop-color="#E4F1FF"/>
     </linearGradient>
-    <radialGradient id="paint1_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(320 640) rotate(90) scale(280)">
-      <stop stop-color="#62FFD5" stop-opacity="0.5"/>
-      <stop offset="1" stop-color="#62FFD5" stop-opacity="0"/>
+    <radialGradient id="spotC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse"
+      gradientTransform="translate(360 640) rotate(90) scale(360)">
+      <stop offset="0" stop-color="#51BAFF" stop-opacity="0.35"/>
+      <stop offset="1" stop-color="#51BAFF" stop-opacity="0"/>
     </radialGradient>
-    <radialGradient id="paint2_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1580 320) rotate(90) scale(220)">
-      <stop stop-color="#3BA9FF" stop-opacity="0.55"/>
-      <stop offset="1" stop-color="#3BA9FF" stop-opacity="0"/>
+    <radialGradient id="spotD" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse"
+      gradientTransform="translate(1580 320) rotate(90) scale(320)">
+      <stop offset="0" stop-color="#2EA3F2" stop-opacity="0.42"/>
+      <stop offset="1" stop-color="#2EA3F2" stop-opacity="0"/>
     </radialGradient>
+    <linearGradient id="tablet" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#FFFFFF"/>
+      <stop offset="1" stop-color="#EEF4FF"/>
+    </linearGradient>
   </defs>
+  <rect width="1920" height="960" fill="url(#bgGradient03)"/>
+  <circle cx="360" cy="640" r="360" fill="url(#spotC)"/>
+  <circle cx="1560" cy="320" r="320" fill="url(#spotD)"/>
+  <path d="M0 760C340 640 640 600 960 620C1280 640 1620 700 1920 820V960H0V760Z" fill="#D5E6FA" fill-opacity="0.45"/>
+  <g transform="translate(1130 200)">
+    <rect x="0" y="0" width="320" height="440" rx="44" fill="url(#tablet)" stroke="#D2E2F8" stroke-width="8"/>
+    <rect x="54" y="88" width="212" height="240" rx="26" fill="#2EA3F2" fill-opacity="0.12"/>
+    <rect x="120" y="348" width="80" height="20" rx="10" fill="#CDDEF5"/>
+    <circle cx="160" cy="52" r="10" fill="#CDDEF5"/>
+  </g>
+  <g transform="translate(1330 170) rotate(12)">
+    <rect x="0" y="0" width="200" height="360" rx="32" fill="#FFFFFF" stroke="#D2E2F8" stroke-width="6"/>
+    <rect x="38" y="72" width="124" height="200" rx="22" fill="#2EA3F2" fill-opacity="0.14"/>
+    <rect x="74" y="292" width="52" height="28" rx="12" fill="#CDDEF5"/>
+    <circle cx="100" cy="40" r="6" fill="#D5E5FA"/>
+  </g>
+  <g transform="translate(970 320) rotate(-10)">
+    <rect x="0" y="0" width="180" height="320" rx="30" fill="#FFFFFF" stroke="#D2E2F8" stroke-width="6"/>
+    <rect x="36" y="64" width="108" height="184" rx="20" fill="#2EA3F2" fill-opacity="0.12"/>
+    <rect x="62" y="264" width="56" height="32" rx="12" fill="#CDDEF5"/>
+    <circle cx="90" cy="36" r="6" fill="#D5E5FA"/>
+  </g>
 </svg>

--- a/src/Resources/app/storefront/src/scss/home.scss
+++ b/src/Resources/app/storefront/src/scss/home.scss
@@ -1,19 +1,20 @@
 .sk-home {
-  background-color: #060b12;
-  color: #f4f7fb;
+  background-color: #ffffff;
+  color: $text-color;
+  font-family: $font-family-base;
 
   .container {
     max-width: 1180px;
     margin: 0 auto;
-    padding: 0 1.75rem;
+    padding: 0 1.5rem;
   }
 }
 
 .sk-home-slider {
   position: relative;
+  height: clamp(520px, 68vh, 680px);
   overflow: hidden;
-  height: clamp(420px, 70vh, 640px);
-  background: #04070c;
+  color: #ffffff;
 
   &__inner {
     position: relative;
@@ -25,52 +26,49 @@
     inset: 0;
     display: flex;
     align-items: center;
-    justify-content: center;
     background-image: var(--sk-slide-bg);
     background-size: cover;
     background-position: center;
-    transition: opacity 0.8s ease, transform 1.6s ease;
     opacity: 0;
-    transform: scale(1.04);
+    transform: translateX(6%);
+    transition: opacity 0.8s ease, transform 1.1s ease;
 
     &.is-active {
       opacity: 1;
-      transform: scale(1);
-      z-index: 1;
+      transform: translateX(0);
+      z-index: 2;
     }
   }
 
   &__overlay {
     position: absolute;
     inset: 0;
-    background: linear-gradient(135deg, rgba(4, 8, 16, 0.85), rgba(9, 28, 39, 0.55));
+    background: linear-gradient(90deg, rgba(16, 32, 56, 0.88) 0%, rgba(16, 32, 56, 0.45) 55%, rgba(16, 32, 56, 0.05) 100%);
     mix-blend-mode: multiply;
   }
 
   &__container {
     position: relative;
-    z-index: 2;
+    z-index: 3;
     width: 100%;
     display: flex;
     align-items: center;
-    justify-content: center;
-    text-align: center;
+    justify-content: flex-start;
   }
 
   &__text {
-    max-width: 620px;
+    max-width: 520px;
 
     h2 {
-      font-size: clamp(2.4rem, 4vw, 3.4rem);
-      font-weight: 700;
+      font-size: clamp(2.6rem, 4.5vw, 3.4rem);
       line-height: 1.1;
-      margin-bottom: 1rem;
+      margin-bottom: 1.25rem;
     }
 
     p {
       font-size: 1.125rem;
-      line-height: 1.7;
-      opacity: 0.88;
+      line-height: 1.8;
+      color: rgba(255, 255, 255, 0.9);
     }
   }
 
@@ -78,56 +76,58 @@
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    padding: 0.35rem 0.85rem;
+    padding: 0.4rem 0.9rem;
     border-radius: 999px;
-    background: rgba(255, 255, 255, 0.12);
-    color: #7ef0cb;
+    background: rgba(255, 255, 255, 0.16);
+    letter-spacing: 0.16em;
     font-size: 0.85rem;
     font-weight: 600;
-    letter-spacing: 0.14em;
     text-transform: uppercase;
     margin-bottom: 1.25rem;
   }
 
+  &__actions {
+    margin-top: 1.75rem;
+  }
+
   &__dots {
     position: absolute;
-    bottom: 1.75rem;
+    bottom: 2rem;
     left: 50%;
     transform: translateX(-50%);
     display: inline-flex;
     gap: 0.75rem;
-    z-index: 3;
+    z-index: 4;
   }
 
   &__dot {
-    position: relative;
     width: 14px;
     height: 14px;
     border-radius: 50%;
-    background: rgba(255, 255, 255, 0.25);
     border: none;
-    padding: 0;
+    background: rgba(255, 255, 255, 0.45);
     cursor: pointer;
-    overflow: hidden;
+    padding: 0;
     transition: transform 0.3s ease, background-color 0.3s ease;
 
     &:focus-visible {
-      outline: 2px solid #7ef0cb;
+      outline: 2px solid rgba(255, 255, 255, 0.8);
       outline-offset: 2px;
     }
 
     &::after {
       content: '';
-      position: absolute;
-      inset: 0;
+      display: block;
+      width: 100%;
+      height: 100%;
       border-radius: 50%;
-      background: linear-gradient(135deg, #62ffd5, #2aa7ff);
+      background: $brand-primary;
       transform: scale(0);
       opacity: 0;
     }
 
     &.is-active {
-      background: rgba(255, 255, 255, 0.45);
+      background: #ffffff;
       transform: scale(1.2);
 
       &::after {
@@ -140,7 +140,7 @@
 @keyframes sk-slider-progress {
   0% {
     transform: scale(0);
-    opacity: 0.2;
+    opacity: 0.25;
   }
   100% {
     transform: scale(1);
@@ -149,97 +149,96 @@
 }
 
 .sk-home-header {
-  padding: clamp(3rem, 6vw, 5rem) 0;
-  background: linear-gradient(135deg, rgba(7, 16, 24, 0.96), rgba(8, 24, 34, 0.96));
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  position: relative;
+  padding: clamp(3.5rem, 7vw, 5.5rem) 0;
+  background: linear-gradient(135deg, rgba(18, 38, 66, 0.94), rgba(28, 52, 88, 0.86));
+  color: #ffffff;
 
   &__inner {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
     gap: 2.5rem;
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
   }
 
   &__texts {
-    max-width: 720px;
+    max-width: 680px;
 
     h1 {
-      font-size: clamp(2.5rem, 4.5vw, 3.6rem);
+      font-size: clamp(2.4rem, 4.3vw, 3.4rem);
       line-height: 1.1;
       margin-bottom: 1.5rem;
     }
 
     p {
-      font-size: 1.1rem;
+      font-size: 1.15rem;
       line-height: 1.8;
-      opacity: 0.86;
+      color: rgba(255, 255, 255, 0.88);
       margin: 0;
     }
   }
 
   &__eyebrow {
     display: inline-flex;
-    padding: 0.3rem 0.75rem;
+    padding: 0.35rem 0.85rem;
     border-radius: 999px;
     background: rgba(255, 255, 255, 0.12);
-    font-size: 0.85rem;
-    letter-spacing: 0.12em;
+    letter-spacing: 0.18em;
+    font-size: 0.82rem;
     text-transform: uppercase;
-    color: #a0ffdd;
+    font-weight: 600;
     margin-bottom: 1rem;
   }
 
   &__cta {
     display: flex;
-    justify-content: flex-start;
+    justify-content: flex-end;
   }
 
   &__whatsapp {
     display: inline-flex;
     align-items: center;
     gap: 0.75rem;
-    padding: 0.9rem 1.6rem;
+    padding: 0.85rem 1.6rem;
     border-radius: 999px;
-    background: linear-gradient(135deg, #2dd37a, #0f9a51);
-    color: #041115;
+    background: #ffffff;
+    color: #128C7E;
     font-weight: 700;
-    font-size: 1rem;
-    text-decoration: none;
-    box-shadow: 0 18px 35px rgba(6, 175, 103, 0.25);
+    box-shadow: 0 18px 30px rgba(0, 0, 0, 0.18);
     transition: transform 0.3s ease, box-shadow 0.3s ease;
 
     img {
-      width: 32px;
-      height: 32px;
+      width: 34px;
+      height: 34px;
     }
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
       transform: translateY(-3px);
-      box-shadow: 0 22px 40px rgba(6, 175, 103, 0.35);
+      box-shadow: 0 24px 40px rgba(0, 0, 0, 0.2);
     }
   }
 }
 
 .sk-home-intro {
   padding: clamp(4rem, 7vw, 6rem) 0;
-  background: #070f18;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  background: #f5f8ff;
+  text-align: center;
 
-  &__content {
-    max-width: 820px;
-    margin: 0 auto;
-    text-align: center;
+  &__lead {
+    max-width: 860px;
+    margin: 0 auto 2rem;
 
     h2 {
       font-size: clamp(2rem, 4vw, 2.8rem);
-      margin-bottom: 1.75rem;
+      margin-bottom: 1.5rem;
     }
 
     p {
       font-size: 1.05rem;
-      line-height: 1.8;
-      opacity: 0.85;
-      margin-bottom: 1.35rem;
+      line-height: 1.9;
+      color: $text-color;
+      margin-bottom: 1.25rem;
     }
   }
 
@@ -247,66 +246,235 @@
     display: inline-flex;
     flex-wrap: wrap;
     justify-content: center;
-    gap: 0.75rem 1.25rem;
-    margin: 2rem 0 2.5rem;
+    gap: 0.8rem 1.25rem;
+    margin: 0 auto 2.5rem;
     padding: 0;
     list-style: none;
 
     li {
-      padding: 0.65rem 1.25rem;
+      padding: 0.6rem 1.25rem;
       border-radius: 999px;
-      background: rgba(255, 255, 255, 0.08);
+      background: rgba($brand-primary, 0.12);
+      color: $brand-primary-dark;
       font-weight: 600;
       letter-spacing: 0.02em;
+    }
+  }
+
+  &__note {
+    max-width: 760px;
+    margin: 0 auto;
+    font-size: 1.05rem;
+    line-height: 1.85;
+    color: $text-color-muted;
+  }
+}
+
+.sk-home-highlight {
+  padding: clamp(4rem, 7vw, 6.5rem) 0;
+  background: #ffffff;
+
+  &--reverse {
+    background: #f7faff;
+
+    .sk-home-highlight__grid {
+      direction: rtl;
+
+      > * {
+        direction: ltr;
+      }
+    }
+  }
+
+  &__grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 3rem;
+    align-items: center;
+  }
+
+  &__text {
+    max-width: 540px;
+
+    h2 {
+      font-size: clamp(2.1rem, 3.6vw, 2.9rem);
+      margin-bottom: 1.5rem;
+      color: $text-color;
+    }
+
+    p {
+      font-size: 1.05rem;
+      line-height: 1.9;
+      color: $text-color;
+      margin-bottom: 1.2rem;
+    }
+  }
+
+  &__eyebrow {
+    display: inline-flex;
+    padding: 0.32rem 0.75rem;
+    border-radius: 999px;
+    background: rgba($brand-primary, 0.12);
+    color: $brand-primary;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    font-size: 0.8rem;
+    font-weight: 600;
+    margin-bottom: 1.2rem;
+  }
+
+  &__list {
+    margin: 1.5rem 0 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 0.75rem;
+
+    li {
+      position: relative;
+      padding-left: 1.75rem;
+      font-weight: 600;
+      color: $text-color;
+
+      &::before {
+        content: '';
+        position: absolute;
+        top: 0.45rem;
+        left: 0;
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: $brand-primary;
+        box-shadow: 0 0 0 4px rgba($brand-primary, 0.16);
+      }
+    }
+  }
+
+  &__media {
+    text-align: center;
+
+    img {
+      max-width: 100%;
+      height: auto;
+      filter: drop-shadow(0 28px 40px rgba(15, 73, 122, 0.18));
     }
   }
 }
 
 .sk-home-counter {
-  padding: clamp(3rem, 6vw, 5rem) 0 6rem;
-  background: linear-gradient(180deg, rgba(6, 11, 18, 0.95) 0%, rgba(5, 9, 15, 0.95) 100%);
+  padding: clamp(4rem, 7vw, 6rem) 0;
+  background: linear-gradient(135deg, #2ea3f2 0%, #1f7bb8 100%);
+  color: #ffffff;
+  text-align: center;
+
+  h2 {
+    font-size: clamp(2.1rem, 4vw, 3rem);
+    margin-bottom: 0.75rem;
+  }
+
+  &__intro {
+    font-size: 1.05rem;
+    max-width: 760px;
+    margin: 0 auto 3rem;
+    line-height: 1.8;
+    color: rgba(255, 255, 255, 0.9);
+  }
 
   &__grid {
     display: grid;
-    gap: 1.5rem;
     grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 2.5rem;
   }
 
   &__item {
-    background: rgba(7, 17, 25, 0.88);
-    border-radius: 18px;
-    padding: 2.5rem 1.5rem;
-    text-align: center;
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+    display: grid;
+    justify-items: center;
+    gap: 1rem;
+  }
 
-    &:nth-child(2) {
-      transform: translateY(20px);
+  &__circle {
+    width: 200px;
+    height: 200px;
+    border-radius: 50%;
+    border: 8px solid rgba(255, 255, 255, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    box-shadow: 0 24px 44px rgba(0, 0, 0, 0.18);
+
+    &::after {
+      content: '';
+      position: absolute;
+      inset: 16px;
+      border-radius: 50%;
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    span {
+      position: relative;
+      z-index: 1;
     }
   }
 
   &__value {
-    display: block;
-    font-size: clamp(2.2rem, 4vw, 3.2rem);
+    font-size: clamp(2.6rem, 5vw, 3.6rem);
     font-weight: 800;
-    letter-spacing: 0.04em;
-    color: #7ef0cb;
-    margin-bottom: 0.75rem;
+    letter-spacing: 0.06em;
   }
 
   &__label {
     font-size: 0.95rem;
-    text-transform: uppercase;
     letter-spacing: 0.18em;
-    opacity: 0.76;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.85);
+  }
+}
+
+.sk-home-cta {
+  padding: clamp(3.5rem, 7vw, 5rem) 0;
+  background: #f2f8ff;
+  text-align: center;
+
+  h2 {
+    font-size: clamp(2.1rem, 4vw, 3rem);
+    margin-bottom: 1rem;
+  }
+
+  p {
+    font-size: 1.1rem;
+    max-width: 760px;
+    margin: 0 auto 2rem;
+    line-height: 1.8;
+    color: $text-color;
+  }
+
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: center;
+  }
+
+  .btn-outline {
+    border-width: 2px;
   }
 }
 
 @media (max-width: 992px) {
   .sk-home-slider {
-    height: clamp(380px, 68vh, 520px);
+    height: clamp(440px, 70vh, 560px);
 
     &__container {
-      text-align: left;
+      justify-content: center;
+    }
+
+    &__text {
+      text-align: center;
+
+      h2 {
+        font-size: clamp(2.2rem, 6vw, 2.8rem);
+      }
     }
   }
 
@@ -321,27 +489,50 @@
     }
   }
 
-  .sk-home-counter__item:nth-child(2) {
-    transform: none;
+  .sk-home-highlight__grid {
+    grid-template-columns: 1fr;
+    gap: 2.5rem;
+  }
+
+  .sk-home-highlight--reverse .sk-home-highlight__grid {
+    direction: ltr;
+  }
+
+  .sk-home-counter__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 640px) {
   .sk-home-slider {
-    &__text {
-      p {
-        font-size: 1rem;
-      }
-    }
+    height: 440px;
 
     &__dots {
       bottom: 1.25rem;
     }
+
+    &__text {
+      h2 {
+        font-size: 2rem;
+      }
+
+      p {
+        font-size: 1rem;
+      }
+    }
   }
 
-  .sk-home-counter {
-    &__grid {
-      grid-template-columns: 1fr;
-    }
+  .sk-home-intro__list li {
+    width: 100%;
+    text-align: center;
+  }
+
+  .sk-home-counter__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sk-home-counter__circle {
+    width: 180px;
+    height: 180px;
   }
 }

--- a/src/Resources/snippet/de-DE/storefront.json
+++ b/src/Resources/snippet/de-DE/storefront.json
@@ -1,47 +1,79 @@
 {
     "skylad": {
         "topbar": {
-            "text": "🚚 Kostenloser Versand ab 50€"
+            "text": "📍 Reparaturservice in Pirmasens & Umgebung"
         },
         "home": {
             "slider": {
                 "aria": "Folie",
+                "buttonLabel": "Reparatur anfragen",
+                "buttonLink": "https://api.whatsapp.com/send?phone=4917631371638&text=Hallo%20Skylad%20Repair",
                 "slide1": {
-                    "tag": "Express Service",
-                    "title": "Smartphone-Reparaturen binnen 60 Minuten",
-                    "text": "Displays, Akkus und Ladebuchsen tauschen wir direkt in unserer Skylad-Werkstatt – transparent, sicher und mit Originalteilen."
+                    "tag": "Express Reparatur",
+                    "title": "Handy- & Tablet-Reparatur in Pirmasens",
+                    "text": "Displaybruch, Akku oder Ladebuchse – wir beheben Schäden direkt in unserer Werkstatt und liefern dein Gerät funktionstüchtig zurück."
                 },
                 "slide2": {
-                    "tag": "Sorgfältige Diagnose",
-                    "title": "Wir finden jedes versteckte Hardwareproblem",
-                    "text": "Mit modernsten Prüfständen prüfen wir Feuchtigkeitsschäden, Datenleitungen und Mikroelektronik, bevor der Schaden größer wird."
+                    "tag": "Diagnose inklusive",
+                    "title": "Wir finden jeden Hardware-Fehler",
+                    "text": "Feuchtigkeitsschäden, Mikro-Lötarbeiten oder Datensicherung – unser Team prüft alle Komponenten mit Profi-Equipment."
                 },
                 "slide3": {
-                    "tag": "Vor-Ort Beratung",
-                    "title": "Technikhilfe, die zu deinem Alltag passt",
-                    "text": "Ob Business-Geräte oder Familien-Tablets: wir beraten persönlich, holen Geräte ab und liefern sie einsatzbereit zurück."
+                    "tag": "Hol- & Bring-Service",
+                    "title": "Unkompliziert vom Auftrag bis zur Lieferung",
+                    "text": "Wir holen defekte Geräte zuhause ab, reparieren sie schnell und bringen sie anschließend sicher wieder vorbei."
                 }
             },
             "header": {
-                "eyebrow": "Willkommen bei Skylad Repair",
-                "title": "Willkommen bei Skylad – deine Technikwerkstatt in Nürnberg",
-                "text": "Wir retten Lieblingsgeräte, beraten zu Upgrades und halten Unternehmen mit wartungsstarken Servicepaketen in Bewegung.",
-                "whatsAppLabel": "Jetzt via WhatsApp anfragen",
-                "whatsAppLink": "https://wa.me/499112223344"
+                "eyebrow": "Willkommen auf der Website von Reparaturservice Fahrenbruch",
+                "title": "Ihr Smartphone oder Tablet ist kaputt? Dann sind Sie bei uns genau richtig!",
+                "text": "Egal ob Wasserschaden, defekter Akku oder gebrochenes Glas – wir reparieren Handys, Tablets und Notebooks aller bekannten Marken zuverlässig und mit Garantie.",
+                "whatsAppLabel": "jetzt direkt über WhatsApp anfragen",
+                "whatsAppLink": "https://api.whatsapp.com/send?phone=4917631371638&text=Hallo%20Skylad%20Repair"
             },
             "intro": {
-                "title": "Mehr als nur Display-Reparaturen",
-                "text1": "Seit über zehn Jahren kümmern wir uns als Meisterbetrieb um Smartphones, Tablets, Laptops und Wearables aller großen Hersteller.",
-                "text2": "Unser Team aus zertifizierten Techniker:innen arbeitet ESD-geschützt, dokumentiert jeden Schritt digital und hält dich über jeden Status transparent auf dem Laufenden.",
-                "list1": "Apple iPhone, iPad & MacBook Serien",
+                "title": "Fachwerkstatt mit Original-Ersatzteilen",
+                "text1": "Wir setzen ausschließlich geprüfte Bauteile ein und dokumentieren jede Reparatur digital. So behalten Sie den Überblick und erhalten Ihr Gerät schnellstmöglich zurück.",
+                "text2": "Alle Reparaturen werden von geschulten Techniker:innen unter ESD-Schutz durchgeführt – inklusive umfassender Funktionsprüfung.",
+                "list1": "Apple iPhone, iPad & MacBook",
                 "list2": "Samsung Galaxy Smartphones & Tablets",
                 "list3": "HP, Lenovo, Dell & Microsoft Notebooks",
-                "text3": "Vom Glasbruch bis zum Mainboard-Repair – inklusive Ersatzteilbeschaffung, Datenrettung und hauseigenem Geräteleihservice."
+                "text3": "Auf Wunsch holen wir defekte Geräte bei Ihnen ab, retten Daten und stellen bei Bedarf ein Leihgerät bereit."
+            },
+            "highlight1": {
+                "eyebrow": "Reparaturservice",
+                "title": "Schnell & zuverlässig",
+                "text1": "Unser Team arbeitet mit viel Erfahrung und Fingerspitzengefühl. Dadurch tauschen wir Displays, Akkus oder Kameras innerhalb kürzester Zeit aus.",
+                "text2": "Von der Diagnose bis zur Endkontrolle bleiben Sie über jeden Schritt informiert und können Ihre Reparatur bequem online verfolgen.",
+                "list1": "Kostenlose Schadensanalyse vor Auftrag",
+                "list2": "Verwendung hochwertiger Ersatzteile",
+                "list3": "Transparente Preise ohne versteckte Gebühren",
+                "alt": "Illustration eines Smartphones mit Checkliste"
+            },
+            "highlight2": {
+                "eyebrow": "Hol- & Bring-Service",
+                "title": "Einfach & unkompliziert",
+                "text1": "Im Raum Pirmasens holen wir Ihr defektes Gerät ab und liefern es repariert wieder bei Ihnen an – ideal für Unternehmen und private Haushalte.",
+                "text2": "Auf Wunsch übernehmen wir auch die Einrichtung, spielen Updates ein und sichern Ihre Daten vor der Übergabe.",
+                "list1": "Flexible Abholzeiten nach Vereinbarung",
+                "list2": "Versicherter Transport Ihrer Geräte",
+                "list3": "Optionaler Vor-Ort-Einrichtungsservice",
+                "alt": "Illustration eines Lieferwagens mit Paket"
             },
             "counter": {
+                "title": "Unsere Werkstatt in Zahlen",
+                "text": "Seit über zehn Jahren vertrauen Kund:innen auf unseren Reparaturservice – mit hunderten reparierten Geräten und reichlich Koffein im Team.",
                 "smartphone": "SMARTPHONE REPARATUREN",
                 "coffee": "TASSEN KAFFEE",
                 "tablet": "TABLET & LAPTOP REPARATUREN"
+            },
+            "cta": {
+                "title": "Bereit für deine Reparatur?",
+                "text": "Schreib uns direkt via WhatsApp oder ruf an – wir beraten dich persönlich, erstellen ein unverbindliches Angebot und kümmern uns um den Rest.",
+                "buttonLabel": "Jetzt WhatsApp öffnen",
+                "buttonLink": "https://api.whatsapp.com/send?phone=4917631371638&text=Hallo%20Skylad%20Repair",
+                "phoneLabel": "Telefonisch beraten lassen",
+                "phoneNumberPlain": "+4917631371638"
             }
         }
     }

--- a/src/Resources/snippet/en-GB/storefront.json
+++ b/src/Resources/snippet/en-GB/storefront.json
@@ -1,47 +1,79 @@
 {
     "skylad": {
         "topbar": {
-            "text": "🚚 Free shipping from 50€"
+            "text": "📍 Repair service in Pirmasens & surrounding area"
         },
         "home": {
             "slider": {
                 "aria": "Slide",
+                "buttonLabel": "Request a repair",
+                "buttonLink": "https://api.whatsapp.com/send?phone=4917631371638&text=Hello%20Skylad%20Repair",
                 "slide1": {
-                    "tag": "Express service",
-                    "title": "Smartphone repairs within 60 minutes",
-                    "text": "We replace displays, batteries and charging ports directly in our Skylad lab – transparent, safe and with genuine parts."
+                    "tag": "Express repair",
+                    "title": "Smartphone & tablet repairs in Pirmasens",
+                    "text": "Broken displays, weak batteries or charging ports – we fix every defect in our workshop and return your device ready to use."
                 },
                 "slide2": {
-                    "tag": "Detailed diagnostics",
-                    "title": "We uncover every hidden hardware issue",
-                    "text": "With state-of-the-art benches we check liquid damage, data lines and micro electronics before the damage escalates."
+                    "tag": "Diagnostics included",
+                    "title": "We uncover every hardware issue",
+                    "text": "Liquid damage, micro soldering or data recovery – our technicians check each component with professional equipment."
                 },
                 "slide3": {
-                    "tag": "In-store consulting",
-                    "title": "Tech support that fits your daily routine",
-                    "text": "From business devices to family tablets: we consult in person, collect your gear and return it ready for use."
+                    "tag": "Pickup & delivery",
+                    "title": "Convenient from order to handover",
+                    "text": "We collect faulty devices at your home, repair them quickly and bring them back safely afterwards."
                 }
             },
             "header": {
-                "eyebrow": "Welcome to Skylad Repair",
-                "title": "Welcome to Skylad – your tech workshop in Nuremberg",
-                "text": "We rescue favourite devices, advise on upgrades and keep companies moving with reliable service packages.",
-                "whatsAppLabel": "Contact us on WhatsApp",
-                "whatsAppLink": "https://wa.me/499112223344"
+                "eyebrow": "Welcome to Reparaturservice Fahrenbruch",
+                "title": "Your phone or tablet stopped working? You are at the right place!",
+                "text": "Whether water damage, broken glass or weak batteries – we repair phones, tablets and notebooks from all major brands reliably and with warranty.",
+                "whatsAppLabel": "contact us on WhatsApp",
+                "whatsAppLink": "https://api.whatsapp.com/send?phone=4917631371638&text=Hello%20Skylad%20Repair"
             },
             "intro": {
-                "title": "More than display repairs",
-                "text1": "For over a decade our certified team has taken care of smartphones, tablets, laptops and wearables from all leading brands.",
-                "text2": "Working in ESD-protected labs we document each step digitally and keep you informed about the current status at all times.",
-                "list1": "Apple iPhone, iPad & MacBook lines",
-                "list2": "Samsung Galaxy phones & tablets",
+                "title": "Certified workshop using genuine spare parts",
+                "text1": "We only use tested components and document every repair digitally. This keeps you informed and guarantees a quick turnaround.",
+                "text2": "All repairs are handled by trained technicians under ESD protection – including extensive function tests.",
+                "list1": "Apple iPhone, iPad & MacBook",
+                "list2": "Samsung Galaxy smartphones & tablets",
                 "list3": "HP, Lenovo, Dell & Microsoft notebooks",
-                "text3": "From cracked glass to board level repairs – including spare part sourcing, data recovery and our in-house device loan service."
+                "text3": "On request we collect devices, secure your data and provide a loan device if needed."
+            },
+            "highlight1": {
+                "eyebrow": "Repair service",
+                "title": "Fast & reliable",
+                "text1": "Thanks to many years of experience we replace displays, batteries or cameras within a very short time.",
+                "text2": "From diagnostics to final check you are informed about each step and can track your repair online.",
+                "list1": "Free damage check before approval",
+                "list2": "High quality spare parts only",
+                "list3": "Transparent pricing without hidden fees",
+                "alt": "Illustration of a smartphone with checklist"
+            },
+            "highlight2": {
+                "eyebrow": "Pickup & delivery",
+                "title": "Simple & convenient",
+                "text1": "Within the Pirmasens area we pick up your device and return it repaired – perfect for households and businesses.",
+                "text2": "We also set up software, install updates and secure your data before handover if required.",
+                "list1": "Flexible pickup appointments",
+                "list2": "Insured transport of your devices",
+                "list3": "Optional on-site setup service",
+                "alt": "Illustration of a delivery van with parcel"
             },
             "counter": {
+                "title": "Our workshop in numbers",
+                "text": "Customers have trusted our repair service for more than ten years – hundreds of fixed devices and quite a lot of coffee keep us going.",
                 "smartphone": "SMARTPHONE REPAIRS",
                 "coffee": "CUPS OF COFFEE",
                 "tablet": "TABLET & LAPTOP REPAIRS"
+            },
+            "cta": {
+                "title": "Ready for your repair?",
+                "text": "Send us a WhatsApp message or give us a call – we provide personal advice, create a non-binding offer and take care of everything else.",
+                "buttonLabel": "Open WhatsApp now",
+                "buttonLink": "https://api.whatsapp.com/send?phone=4917631371638&text=Hello%20Skylad%20Repair",
+                "phoneLabel": "Get advice by phone",
+                "phoneNumberPlain": "+4917631371638"
             }
         }
     }

--- a/src/Resources/views/storefront/page/content/index.html.twig
+++ b/src/Resources/views/storefront/page/content/index.html.twig
@@ -1,6 +1,7 @@
 {#
-This overrides the default CMS content page. It renders a custom landing layout
-for the homepage when no Shopping Experience is assigned.
+    Custom homepage layout replicating the Divi-style landing page from the
+    reference site. All texts live in the snippet files so merchants can edit
+    them without touching the template.
 #}
 {% sw_extends '@Storefront/storefront/page/content/index.html.twig' %}
 
@@ -16,6 +17,11 @@ for the homepage when no Shopping Experience is assigned.
                                 <span class="sk-home-slider__tag">{{ 'skylad.home.slider.slide1.tag'|trans }}</span>
                                 <h2>{{ 'skylad.home.slider.slide1.title'|trans }}</h2>
                                 <p>{{ 'skylad.home.slider.slide1.text'|trans }}</p>
+                                <div class="sk-home-slider__actions">
+                                    <a class="btn" href="{{ 'skylad.home.slider.buttonLink'|trans }}">
+                                        {{ 'skylad.home.slider.buttonLabel'|trans }}
+                                    </a>
+                                </div>
                             </div>
                         </div>
                     </article>
@@ -26,6 +32,11 @@ for the homepage when no Shopping Experience is assigned.
                                 <span class="sk-home-slider__tag">{{ 'skylad.home.slider.slide2.tag'|trans }}</span>
                                 <h2>{{ 'skylad.home.slider.slide2.title'|trans }}</h2>
                                 <p>{{ 'skylad.home.slider.slide2.text'|trans }}</p>
+                                <div class="sk-home-slider__actions">
+                                    <a class="btn" href="{{ 'skylad.home.slider.buttonLink'|trans }}">
+                                        {{ 'skylad.home.slider.buttonLabel'|trans }}
+                                    </a>
+                                </div>
                             </div>
                         </div>
                     </article>
@@ -36,6 +47,11 @@ for the homepage when no Shopping Experience is assigned.
                                 <span class="sk-home-slider__tag">{{ 'skylad.home.slider.slide3.tag'|trans }}</span>
                                 <h2>{{ 'skylad.home.slider.slide3.title'|trans }}</h2>
                                 <p>{{ 'skylad.home.slider.slide3.text'|trans }}</p>
+                                <div class="sk-home-slider__actions">
+                                    <a class="btn" href="{{ 'skylad.home.slider.buttonLink'|trans }}">
+                                        {{ 'skylad.home.slider.buttonLabel'|trans }}
+                                    </a>
+                                </div>
                             </div>
                         </div>
                     </article>
@@ -63,35 +79,100 @@ for the homepage when no Shopping Experience is assigned.
 
             <section class="sk-home-intro">
                 <div class="container">
-                    <div class="sk-home-intro__content">
+                    <div class="sk-home-intro__lead">
                         <h2>{{ 'skylad.home.intro.title'|trans }}</h2>
                         <p>{{ 'skylad.home.intro.text1'|trans }}</p>
                         <p>{{ 'skylad.home.intro.text2'|trans }}</p>
-                        <ul class="sk-home-intro__list">
-                            <li>{{ 'skylad.home.intro.list1'|trans }}</li>
-                            <li>{{ 'skylad.home.intro.list2'|trans }}</li>
-                            <li>{{ 'skylad.home.intro.list3'|trans }}</li>
-                        </ul>
-                        <p>{{ 'skylad.home.intro.text3'|trans }}</p>
+                    </div>
+                    <ul class="sk-home-intro__list">
+                        <li>{{ 'skylad.home.intro.list1'|trans }}</li>
+                        <li>{{ 'skylad.home.intro.list2'|trans }}</li>
+                        <li>{{ 'skylad.home.intro.list3'|trans }}</li>
+                    </ul>
+                    <p class="sk-home-intro__note">{{ 'skylad.home.intro.text3'|trans }}</p>
+                </div>
+            </section>
+
+            <section class="sk-home-highlight">
+                <div class="container">
+                    <div class="sk-home-highlight__grid">
+                        <div class="sk-home-highlight__text">
+                            <span class="sk-home-highlight__eyebrow">{{ 'skylad.home.highlight1.eyebrow'|trans }}</span>
+                            <h2>{{ 'skylad.home.highlight1.title'|trans }}</h2>
+                            <p>{{ 'skylad.home.highlight1.text1'|trans }}</p>
+                            <p>{{ 'skylad.home.highlight1.text2'|trans }}</p>
+                            <ul class="sk-home-highlight__list">
+                                <li>{{ 'skylad.home.highlight1.list1'|trans }}</li>
+                                <li>{{ 'skylad.home.highlight1.list2'|trans }}</li>
+                                <li>{{ 'skylad.home.highlight1.list3'|trans }}</li>
+                            </ul>
+                        </div>
+                        <figure class="sk-home-highlight__media">
+                            <img src="{{ asset('bundles/skyladtheme/assets/highlight-service.svg') }}" alt="{{ 'skylad.home.highlight1.alt'|trans }}">
+                        </figure>
+                    </div>
+                </div>
+            </section>
+
+            <section class="sk-home-highlight sk-home-highlight--reverse">
+                <div class="container">
+                    <div class="sk-home-highlight__grid">
+                        <div class="sk-home-highlight__text">
+                            <span class="sk-home-highlight__eyebrow">{{ 'skylad.home.highlight2.eyebrow'|trans }}</span>
+                            <h2>{{ 'skylad.home.highlight2.title'|trans }}</h2>
+                            <p>{{ 'skylad.home.highlight2.text1'|trans }}</p>
+                            <p>{{ 'skylad.home.highlight2.text2'|trans }}</p>
+                            <ul class="sk-home-highlight__list">
+                                <li>{{ 'skylad.home.highlight2.list1'|trans }}</li>
+                                <li>{{ 'skylad.home.highlight2.list2'|trans }}</li>
+                                <li>{{ 'skylad.home.highlight2.list3'|trans }}</li>
+                            </ul>
+                        </div>
+                        <figure class="sk-home-highlight__media">
+                            <img src="{{ asset('bundles/skyladtheme/assets/highlight-delivery.svg') }}" alt="{{ 'skylad.home.highlight2.alt'|trans }}">
+                        </figure>
                     </div>
                 </div>
             </section>
 
             <section class="sk-home-counter">
                 <div class="container">
+                    <h2>{{ 'skylad.home.counter.title'|trans }}</h2>
+                    <p class="sk-home-counter__intro">{{ 'skylad.home.counter.text'|trans }}</p>
                     <div class="sk-home-counter__grid">
                         <article class="sk-home-counter__item">
-                            <span class="sk-home-counter__value">771</span>
+                            <div class="sk-home-counter__circle">
+                                <span class="sk-home-counter__value">771</span>
+                            </div>
                             <span class="sk-home-counter__label">{{ 'skylad.home.counter.smartphone'|trans }}</span>
                         </article>
                         <article class="sk-home-counter__item">
-                            <span class="sk-home-counter__value">1120</span>
+                            <div class="sk-home-counter__circle">
+                                <span class="sk-home-counter__value">1120</span>
+                            </div>
                             <span class="sk-home-counter__label">{{ 'skylad.home.counter.coffee'|trans }}</span>
                         </article>
                         <article class="sk-home-counter__item">
-                            <span class="sk-home-counter__value">355</span>
+                            <div class="sk-home-counter__circle">
+                                <span class="sk-home-counter__value">355</span>
+                            </div>
                             <span class="sk-home-counter__label">{{ 'skylad.home.counter.tablet'|trans }}</span>
                         </article>
+                    </div>
+                </div>
+            </section>
+
+            <section class="sk-home-cta">
+                <div class="container">
+                    <h2>{{ 'skylad.home.cta.title'|trans }}</h2>
+                    <p>{{ 'skylad.home.cta.text'|trans }}</p>
+                    <div class="sk-home-cta__actions">
+                        <a class="btn" href="{{ 'skylad.home.cta.buttonLink'|trans }}">
+                            {{ 'skylad.home.cta.buttonLabel'|trans }}
+                        </a>
+                        <a class="btn-outline" href="tel:{{ 'skylad.home.cta.phoneNumberPlain'|trans }}">
+                            {{ 'skylad.home.cta.phoneLabel'|trans }}
+                        </a>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
## Summary
- replace the homepage override with a Divi-inspired slider, service highlights, counters and CTA sections
- restyle the home SCSS to the light Divi palette and add responsive behaviour for the new layout
- refresh slider artwork, add highlight illustrations and update the snippets for all new copy and links

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68c9d387420083299629d87406270e5c