### PR TITLE
Create Divi-style header with top bar navigation

### DIFF
--- a/src/Resources/app/storefront/src/scss/_header.scss
+++ b/src/Resources/app/storefront/src/scss/_header.scss
@@ -1,0 +1,219 @@
+/*
+Divi-inspired header styling for Skylad Theme
+==================================================
+Sets up the compact top-bar, main navigation row and WhatsApp call-to-action
+button styling. The layout focuses on a balanced horizontal structure on large
+screens and stacks gracefully on smaller devices.
+*/
+
+.skylad-header {
+    background: $surface-bg;
+    color: $text-color;
+    box-shadow: 0 16px 32px rgba($brand-dark-grey, 0.05);
+
+    a {
+        color: inherit;
+        text-decoration: none;
+    }
+
+    &__top-bar {
+        background: $brand-dark-grey;
+        color: rgba($brand-primary-contrast, 0.88);
+        font-size: 0.75rem;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        padding: 0.4rem 0;
+    }
+
+    &__top-bar-inner {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: center;
+        gap: 0.75rem 1.5rem;
+        text-align: center;
+    }
+
+    &__top-bar-item {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+
+        &--whatsapp {
+            color: $brand-primary-contrast;
+            font-weight: 600;
+
+            &:hover,
+            &:focus {
+                color: lighten($brand-primary-contrast, 6%);
+            }
+        }
+    }
+
+    &__main {
+        background: $surface-bg;
+        border-bottom: 1px solid rgba($brand-dark-grey, 0.08);
+        padding: 1.25rem 0;
+    }
+
+    &__main-inner {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 2rem;
+        flex-wrap: wrap;
+    }
+
+    &__logo,
+    &__cta {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+    }
+
+    &__logo-inner {
+        display: inline-flex;
+        align-items: center;
+    }
+
+    &__logo-link {
+        display: inline-flex;
+        align-items: center;
+    }
+
+    &__logo-picture {
+        display: block;
+        max-height: 64px;
+    }
+
+    &__logo-image {
+        width: auto;
+        max-height: 64px;
+    }
+
+    &__nav {
+        flex: 1 1 auto;
+        display: flex;
+        justify-content: center;
+    }
+
+    &__nav-list {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem 1.75rem;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+    }
+
+    &__nav-link {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        padding: 0.35rem 0;
+        font-size: 0.875rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: $text-color;
+        transition: color 0.2s ease, transform 0.2s ease;
+
+        &::after {
+            content: "";
+            position: absolute;
+            left: 0;
+            bottom: 0;
+            width: 100%;
+            height: 2px;
+            background: $brand-primary;
+            border-radius: 999px;
+            transform: scaleX(0);
+            transform-origin: center;
+            transition: transform 0.2s ease;
+        }
+
+        &:hover,
+        &:focus {
+            color: $brand-primary;
+
+            &::after {
+                transform: scaleX(1);
+            }
+        }
+
+        &:focus {
+            outline: none;
+            box-shadow: 0 0 0 3px rgba($brand-primary, 0.25);
+            border-radius: 999px;
+            padding-inline: 0.35rem;
+        }
+
+        &.is-active,
+        &[aria-current="page"] {
+            color: $brand-primary;
+
+            &::after {
+                transform: scaleX(1);
+            }
+        }
+    }
+
+    &__cta-button {
+        gap: 0.5rem;
+        padding-inline: 1.5rem;
+        font-size: 0.8125rem;
+    }
+
+    &__cta-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+
+        svg {
+            width: 1.125rem;
+            height: 1.125rem;
+        }
+    }
+
+    &__cta-label {
+        letter-spacing: 0.08em;
+    }
+}
+
+@media (max-width: 991px) {
+    .skylad-header {
+        &__main-inner {
+            justify-content: center;
+            text-align: center;
+        }
+
+        &__logo,
+        &__nav,
+        &__cta {
+            width: 100%;
+            justify-content: center;
+        }
+
+        &__cta {
+            margin-top: 1rem;
+        }
+    }
+}
+
+@media (max-width: 575px) {
+    .skylad-header {
+        &__main {
+            padding: 1rem 0;
+        }
+
+        &__nav-link {
+            letter-spacing: 0.08em;
+        }
+
+        &__cta-button {
+            width: 100%;
+        }
+    }
+}

--- a/src/Resources/app/storefront/src/scss/_overrides.scss
+++ b/src/Resources/app/storefront/src/scss/_overrides.scss
@@ -35,35 +35,71 @@ a {
 }
 
 // Header + footer styling inspired by Divi
-.header-top {
-    background: $surface-muted;
-    color: $text-color-muted;
-    font-size: 0.8125rem;
-    padding: 0.35rem 0;
-
-    a {
-        color: $brand-primary;
-
-        &:hover,
-        &:focus {
-            color: $brand-primary-dark;
-        }
-    }
-}
-
-.header-main {
+.skylad-header {
     background: $surface-bg;
     color: $text-color;
-    border-bottom: 1px solid rgba($text-color, 0.08);
-    box-shadow: 0 8px 24px rgba($text-color, 0.04);
+    font-family: $font-family-base;
+    box-shadow: 0 16px 32px rgba($brand-dark-grey, 0.05);
 
     a {
         color: inherit;
+        transition: color 0.2s ease, box-shadow 0.2s ease;
 
         &:hover,
         &:focus {
             color: $brand-primary;
         }
+    }
+
+    &__top-bar {
+        background: $brand-dark-grey;
+        color: rgba($brand-primary-contrast, 0.9);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+    }
+
+    &__top-bar-item {
+        font-weight: 500;
+        letter-spacing: 0.04em;
+
+        &--whatsapp {
+            font-weight: 600;
+        }
+    }
+
+    &__nav-link {
+        font-family: inherit;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        transition: color 0.2s ease, box-shadow 0.2s ease;
+
+        &:hover,
+        &:focus {
+            color: $brand-primary;
+        }
+
+        &.is-active,
+        &[aria-current='page'] {
+            color: $brand-primary;
+        }
+    }
+
+    &__cta-button {
+        background: linear-gradient(135deg, lighten($brand-primary, 6%), $brand-primary-dark);
+        color: $brand-primary-contrast;
+        border: none;
+        box-shadow: 0 18px 36px rgba($brand-primary, 0.24);
+
+        &:hover,
+        &:focus {
+            background: linear-gradient(135deg, lighten($brand-primary, 12%), $brand-primary);
+            box-shadow: 0 22px 44px rgba($brand-primary, 0.28);
+        }
+    }
+
+    &__cta-icon svg {
+        fill: currentColor;
     }
 }
 

--- a/src/Resources/app/storefront/src/scss/base.scss
+++ b/src/Resources/app/storefront/src/scss/base.scss
@@ -1,4 +1,5 @@
 @import "./variables";
 @import "./buttons";
 @import "./overrides";
+@import "./header";
 @import "./home";

--- a/src/Resources/snippet/de-DE/storefront.json
+++ b/src/Resources/snippet/de-DE/storefront.json
@@ -3,6 +3,43 @@
         "topbar": {
             "text": "📍 Reparaturservice in Pirmasens & Umgebung"
         },
+        "header": {
+            "topBar": {
+                "address": "📍 Reparaturservice Fahrenbruch · Winzler Straße 80, 66955 Pirmasens",
+                "whatsAppLabel": "WhatsApp: +49 176 31371638",
+                "whatsAppLink": "https://api.whatsapp.com/send?phone=4917631371638&text=Hallo%20Skylad%20Repair"
+            },
+            "navigation": {
+                "home": {
+                    "label": "Startseite",
+                    "link": "/"
+                },
+                "apple": {
+                    "label": "Apple",
+                    "link": "/apple/"
+                },
+                "samsung": {
+                    "label": "Samsung",
+                    "link": "/samsung/"
+                },
+                "shop": {
+                    "label": "Shop",
+                    "link": "/shop/"
+                },
+                "lexicon": {
+                    "label": "Lexikon",
+                    "link": "/lexikon/"
+                },
+                "contact": {
+                    "label": "Kontakt",
+                    "link": "/kontakt/"
+                }
+            },
+            "cta": {
+                "whatsAppLabel": "Jetzt via WhatsApp schreiben",
+                "whatsAppLink": "https://api.whatsapp.com/send?phone=4917631371638&text=Hallo%20Skylad%20Repair"
+            }
+        },
         "home": {
             "slider": {
                 "aria": "Folie",

--- a/src/Resources/snippet/en-GB/storefront.json
+++ b/src/Resources/snippet/en-GB/storefront.json
@@ -3,6 +3,43 @@
         "topbar": {
             "text": "📍 Repair service in Pirmasens & surrounding area"
         },
+        "header": {
+            "topBar": {
+                "address": "📍 Repair service Fahrenbruch · Winzler Straße 80, 66955 Pirmasens",
+                "whatsAppLabel": "WhatsApp: +49 176 31371638",
+                "whatsAppLink": "https://api.whatsapp.com/send?phone=4917631371638&text=Hello%20Skylad%20Repair"
+            },
+            "navigation": {
+                "home": {
+                    "label": "Home",
+                    "link": "/"
+                },
+                "apple": {
+                    "label": "Apple",
+                    "link": "/apple/"
+                },
+                "samsung": {
+                    "label": "Samsung",
+                    "link": "/samsung/"
+                },
+                "shop": {
+                    "label": "Shop",
+                    "link": "/shop/"
+                },
+                "lexicon": {
+                    "label": "Lexicon",
+                    "link": "/lexicon/"
+                },
+                "contact": {
+                    "label": "Contact",
+                    "link": "/contact/"
+                }
+            },
+            "cta": {
+                "whatsAppLabel": "Chat via WhatsApp",
+                "whatsAppLink": "https://api.whatsapp.com/send?phone=4917631371638&text=Hello%20Skylad%20Repair"
+            }
+        },
         "home": {
             "slider": {
                 "aria": "Slide",

--- a/src/Resources/views/storefront/layout/header/header.html.twig
+++ b/src/Resources/views/storefront/layout/header/header.html.twig
@@ -1,8 +1,136 @@
 {% sw_extends '@Storefront/storefront/layout/header/header.html.twig' %}
 
+{% set headerWhatsAppLinkTranslation = 'skylad.header.cta.whatsAppLink'|trans %}
+{% set headerWhatsAppLink = headerWhatsAppLinkTranslation == 'skylad.header.cta.whatsAppLink'
+    ? 'skylad.home.header.whatsAppLink'|trans
+    : headerWhatsAppLinkTranslation %}
+
+{% block layout_header %}
+    {% set topBarAddress = 'skylad.header.topBar.address'|trans %}
+    {% set topBarWhatsAppLabel = 'skylad.header.topBar.whatsAppLabel'|trans %}
+    {% set topBarLinkTranslation = 'skylad.header.topBar.whatsAppLink'|trans %}
+    {% set topBarWhatsAppLink = topBarLinkTranslation == 'skylad.header.topBar.whatsAppLink'
+        ? headerWhatsAppLink
+        : topBarLinkTranslation %}
+    {% set hasTopBarAddress = topBarAddress != 'skylad.header.topBar.address' and topBarAddress|trim is not empty %}
+    {% set hasTopBarWhatsApp = topBarWhatsAppLabel != 'skylad.header.topBar.whatsAppLabel' and topBarWhatsAppLabel|trim is not empty %}
+
+    <header class="skylad-header">
+        {% block layout_header_top_bar %}
+            {% if hasTopBarAddress or hasTopBarWhatsApp %}
+                <div class="skylad-header__top-bar">
+                    <div class="container">
+                        <div class="skylad-header__top-bar-inner">
+                            {% if hasTopBarAddress %}
+                                <span class="skylad-header__top-bar-item skylad-header__top-bar-item--address">
+                                    {{ topBarAddress|sw_sanitize }}
+                                </span>
+                            {% endif %}
+
+                            {% if hasTopBarWhatsApp %}
+                                <a class="skylad-header__top-bar-item skylad-header__top-bar-item--whatsapp"
+                                   href="{{ topBarWhatsAppLink|striptags }}"
+                                   target="_blank"
+                                   rel="noopener noreferrer"
+                                    title="{{ topBarWhatsAppLabel|striptags }}">
+                                    {{ topBarWhatsAppLabel|sw_sanitize }}
+                                </a>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+        {% endblock %}
+
+        <div class="skylad-header__main">
+            <div class="container">
+                <div class="skylad-header__main-inner">
+                    {{ block('layout_header_logo') }}
+                    {{ block('layout_header_navigation') }}
+                    {{ block('layout_header_actions') }}
+                </div>
+            </div>
+        </div>
+    </header>
+{% endblock %}
 
 {% block layout_header_logo %}
-<div class="header-logo-main">
-{{ parent() }}
-</div>
+    <div class="skylad-header__logo">
+        {{ parent() }}
+    </div>
+{% endblock %}
+
+{% block layout_header_navigation %}
+    {% set navigationConfig = [
+        { key: 'home' },
+        { key: 'apple' },
+        { key: 'samsung' },
+        { key: 'shop' },
+        { key: 'lexicon' },
+        { key: 'contact' }
+    ] %}
+
+    {% set navItems = [] %}
+    {% for config in navigationConfig %}
+        {% set labelKey = 'skylad.header.navigation.' ~ config.key ~ '.label' %}
+        {% set linkKey = 'skylad.header.navigation.' ~ config.key ~ '.link' %}
+        {% set label = labelKey|trans %}
+        {% set linkTranslation = linkKey|trans %}
+        {% set link = linkTranslation != linkKey ? linkTranslation : (config.key == 'home' ? path('frontend.home.page') : '#') %}
+        {% set navItems = navItems|merge([{ label: label, link: link, key: config.key }]) %}
+    {% endfor %}
+
+    {% set currentRoute = app.request is defined ? app.request.attributes.get('_route') : '' %}
+    {% set currentPath = app.request is defined ? app.request.getPathInfo() : '' %}
+
+    {% set navigationAriaTranslation = 'layout.header.navigationMenu'|trans %}
+    {% set navigationAria = navigationAriaTranslation == 'layout.header.navigationMenu'
+        ? 'Main navigation'
+        : navigationAriaTranslation %}
+
+    <nav class="skylad-header__nav" aria-label="{{ navigationAria|striptags }}">
+        <ul class="skylad-header__nav-list">
+            {% for item in navItems %}
+                {% set link = item.link %}
+                {% set hasLeadingSlash = (link|default('')) starts with '/' %}
+                {% set normalizedLink = hasLeadingSlash ? link|trim('/') : '' %}
+                {% set normalizedPath = currentPath ? currentPath|trim('/') : '' %}
+                {% set isActive = false %}
+
+                {% if item.key == 'home' %}
+                    {% set isActive = currentRoute == 'frontend.home.page' %}
+                {% elseif normalizedLink and normalizedPath and normalizedPath starts with normalizedLink %}
+                    {% set isActive = true %}
+                {% endif %}
+
+                <li class="skylad-header__nav-item">
+                    <a class="skylad-header__nav-link{% if isActive %} is-active{% endif %}"
+                       href="{{ link|striptags }}"
+                       {% if isActive %}aria-current="page"{% endif %}
+                       title="{{ item.label|striptags }}">
+                        {{ item.label|sw_sanitize }}
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
+    </nav>
+{% endblock %}
+
+{% block layout_header_actions %}
+    {% set buttonLabelTranslation = 'skylad.header.cta.whatsAppLabel'|trans %}
+    {% set buttonLabel = buttonLabelTranslation == 'skylad.header.cta.whatsAppLabel'
+        ? 'skylad.home.header.whatsAppLabel'|trans
+        : buttonLabelTranslation %}
+    <div class="skylad-header__cta">
+        <a class="skylad-header__cta-button btn"
+           href="{{ headerWhatsAppLink|striptags }}"
+           target="_blank"
+           rel="noopener noreferrer"
+           title="{{ buttonLabel|striptags }}">
+            <span class="skylad-header__cta-icon" aria-hidden="true">
+                {% sw_icon 'whatsapp' %}
+            </span>
+            <span class="skylad-header__cta-label">{{ buttonLabel|sw_sanitize }}</span>
+        </a>
+    </div>
 {% endblock %}

--- a/src/Resources/views/storefront/layout/header/logo.html.twig
+++ b/src/Resources/views/storefront/layout/header/logo.html.twig
@@ -1,6 +1,41 @@
 {% sw_extends '@Storefront/storefront/layout/header/logo.html.twig' %}
 
+{% block layout_header_logo_inner %}
+    <div class="skylad-header__logo-inner">
+        {{ block('layout_header_logo_link') }}
+    </div>
+{% endblock %}
+
+{% block layout_header_logo_link %}
+    <a class="skylad-header__logo-link"
+       href="{{ path('frontend.home.page') }}"
+       title="{{ 'header.logoLink'|trans|striptags }}">
+        {{ block('layout_header_logo_image') }}
+    </a>
+{% endblock %}
 
 {% block layout_header_logo_image %}
-{{ parent() }}
+    <picture class="skylad-header__logo-picture">
+        {% block layout_header_logo_image_tablet %}
+            {% if theme_config('sw-logo-tablet') and theme_config('sw-logo-tablet') != theme_config('sw-logo-desktop') %}
+                <source srcset="{{ theme_config('sw-logo-tablet')|sw_encode_url }}"
+                        media="(min-width: {{ theme_config('breakpoint.md') }}px) and (max-width: {{ theme_config('breakpoint.lg') - 1 }}px)">
+            {% endif %}
+        {% endblock %}
+
+        {% block layout_header_logo_image_mobile %}
+            {% if theme_config('sw-logo-mobile') and theme_config('sw-logo-mobile') != theme_config('sw-logo-desktop') %}
+                <source srcset="{{ theme_config('sw-logo-mobile')|sw_encode_url }}"
+                        media="(max-width: {{ theme_config('breakpoint.md') - 1 }}px)">
+            {% endif %}
+        {% endblock %}
+
+        {% block layout_header_logo_image_default %}
+            {% if theme_config('sw-logo-desktop') %}
+                <img src="{{ theme_config('sw-logo-desktop')|sw_encode_url }}"
+                     alt="{{ 'header.logoLink'|trans|striptags }}"
+                     class="img-fluid skylad-header__logo-image">
+            {% endif %}
+        {% endblock %}
+    </picture>
 {% endblock %}


### PR DESCRIPTION
## Summary
- rebuild the storefront header with a bespoke top bar, horizontal navigation and WhatsApp CTA driven by new snippets
- align the logo template and add a dedicated header SCSS partial with Divi-inspired styling overrides
- translate top bar texts and navigation labels for de-DE and en-GB locales

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68c9e2adf7dc8329afa3d4e23f618e28