### PR TITLE
Align header layout and styling with Divi reference

### DIFF
--- a/src/Resources/app/storefront/src/scss/_header.scss
+++ b/src/Resources/app/storefront/src/scss/_header.scss
@@ -1,43 +1,60 @@
 /*
 Divi-inspired header styling for Skylad Theme
 ==================================================
-Sets up the compact top-bar, main navigation row and WhatsApp call-to-action
-button styling. The layout focuses on a balanced horizontal structure on large
-screens and stacks gracefully on smaller devices.
+Recreates the two-row header with a slim top bar and a generous navigation row
+that mirrors the original WordPress layout.
 */
 
 .skylad-header {
     background: $surface-bg;
     color: $text-color;
-    box-shadow: 0 16px 32px rgba($brand-dark-grey, 0.05);
+    font-family: $font-family-base;
+    box-shadow: 0 1px 0 rgba($brand-dark-grey, 0.12);
 
     a {
         color: inherit;
         text-decoration: none;
+        transition: color 0.2s ease;
     }
 
     &__top-bar {
         background: $brand-dark-grey;
-        color: rgba($brand-primary-contrast, 0.88);
+        color: rgba($brand-primary-contrast, 0.9);
         font-size: 0.75rem;
-        letter-spacing: 0.05em;
-        text-transform: uppercase;
-        padding: 0.4rem 0;
+        letter-spacing: 0.02em;
+        padding: 0.25rem 0;
     }
 
     &__top-bar-inner {
         display: flex;
-        flex-wrap: wrap;
         align-items: center;
-        justify-content: center;
-        gap: 0.75rem 1.5rem;
-        text-align: center;
+        justify-content: space-between;
+        gap: 1.5rem;
+        min-height: 40px;
+    }
+
+    &__top-bar-left,
+    &__top-bar-right {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+    }
+
+    &__top-bar-right {
+        margin-left: auto;
+        justify-content: flex-end;
     }
 
     &__top-bar-item {
         display: inline-flex;
         align-items: center;
-        gap: 0.4rem;
+        gap: 0.45rem;
+        font-weight: 500;
+
+        &--address {
+            color: rgba($brand-primary-contrast, 0.82);
+        }
 
         &--whatsapp {
             color: $brand-primary-contrast;
@@ -45,23 +62,22 @@ screens and stacks gracefully on smaller devices.
 
             &:hover,
             &:focus {
-                color: lighten($brand-primary-contrast, 6%);
+                color: lighten($brand-primary-contrast, 12%);
             }
         }
     }
 
     &__main {
         background: $surface-bg;
-        border-bottom: 1px solid rgba($brand-dark-grey, 0.08);
-        padding: 1.25rem 0;
+        border-bottom: 1px solid rgba($brand-dark-grey, 0.06);
     }
 
     &__main-inner {
         display: flex;
         align-items: center;
         justify-content: space-between;
-        gap: 2rem;
-        flex-wrap: wrap;
+        gap: 3rem;
+        min-height: 116px;
     }
 
     &__logo,
@@ -71,11 +87,7 @@ screens and stacks gracefully on smaller devices.
         align-items: center;
     }
 
-    &__logo-inner {
-        display: inline-flex;
-        align-items: center;
-    }
-
+    &__logo-inner,
     &__logo-link {
         display: inline-flex;
         align-items: center;
@@ -83,12 +95,12 @@ screens and stacks gracefully on smaller devices.
 
     &__logo-picture {
         display: block;
-        max-height: 64px;
+        max-height: 72px;
     }
 
     &__logo-image {
         width: auto;
-        max-height: 64px;
+        max-height: 72px;
     }
 
     &__nav {
@@ -99,26 +111,29 @@ screens and stacks gracefully on smaller devices.
 
     &__nav-list {
         display: flex;
-        flex-wrap: wrap;
-        align-items: center;
+        align-items: flex-end;
         justify-content: center;
-        gap: 0.5rem 1.75rem;
+        gap: 2.5rem;
         margin: 0;
         padding: 0;
         list-style: none;
+    }
+
+    &__nav-item {
+        display: flex;
     }
 
     &__nav-link {
         position: relative;
         display: inline-flex;
         align-items: center;
-        padding: 0.35rem 0;
-        font-size: 0.875rem;
+        padding: 0 0 1.75rem;
+        font-size: 0.9375rem;
         font-weight: 600;
-        text-transform: uppercase;
-        letter-spacing: 0.12em;
-        color: $text-color;
-        transition: color 0.2s ease, transform 0.2s ease;
+        line-height: 1.1;
+        color: rgba($text-color, 0.68);
+        text-transform: none;
+        letter-spacing: normal;
 
         &::after {
             content: "";
@@ -126,7 +141,7 @@ screens and stacks gracefully on smaller devices.
             left: 0;
             bottom: 0;
             width: 100%;
-            height: 2px;
+            height: 3px;
             background: $brand-primary;
             border-radius: 999px;
             transform: scaleX(0);
@@ -137,17 +152,11 @@ screens and stacks gracefully on smaller devices.
         &:hover,
         &:focus {
             color: $brand-primary;
+            outline: none;
 
             &::after {
                 transform: scaleX(1);
             }
-        }
-
-        &:focus {
-            outline: none;
-            box-shadow: 0 0 0 3px rgba($brand-primary, 0.25);
-            border-radius: 999px;
-            padding-inline: 0.35rem;
         }
 
         &.is-active,
@@ -161,9 +170,26 @@ screens and stacks gracefully on smaller devices.
     }
 
     &__cta-button {
+        display: inline-flex;
+        align-items: center;
         gap: 0.5rem;
-        padding-inline: 1.5rem;
-        font-size: 0.8125rem;
+        padding: 0.75rem 1.75rem;
+        border-radius: 999px;
+        background: linear-gradient(135deg, lighten($brand-primary, 4%), $brand-primary-dark);
+        color: $brand-primary-contrast;
+        font-size: 0.875rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        box-shadow: 0 18px 36px rgba($brand-primary, 0.18);
+        transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+
+        &:hover,
+        &:focus {
+            background: linear-gradient(135deg, lighten($brand-primary, 10%), $brand-primary);
+            box-shadow: 0 22px 44px rgba($brand-primary, 0.28);
+            transform: translateY(-1px);
+            color: $brand-primary-contrast;
+        }
     }
 
     &__cta-icon {
@@ -174,18 +200,49 @@ screens and stacks gracefully on smaller devices.
         svg {
             width: 1.125rem;
             height: 1.125rem;
+            fill: currentColor;
         }
     }
 
     &__cta-label {
-        letter-spacing: 0.08em;
+        letter-spacing: 0.04em;
+        white-space: nowrap;
+    }
+}
+
+@media (max-width: 1199px) {
+    .skylad-header {
+        &__main-inner {
+            gap: 2.25rem;
+            min-height: 104px;
+        }
+
+        &__nav-list {
+            gap: 2rem;
+        }
+
+        &__nav-link {
+            padding-bottom: 1.5rem;
+        }
     }
 }
 
 @media (max-width: 991px) {
     .skylad-header {
-        &__main-inner {
+        &__top-bar-inner {
             justify-content: center;
+            text-align: center;
+        }
+
+        &__top-bar-right {
+            margin-left: 0;
+            justify-content: center;
+        }
+
+        &__main-inner {
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 1.5rem;
             text-align: center;
         }
 
@@ -196,24 +253,50 @@ screens and stacks gracefully on smaller devices.
             justify-content: center;
         }
 
-        &__cta {
-            margin-top: 1rem;
+        &__nav-list {
+            flex-wrap: wrap;
+            gap: 1.25rem 1.75rem;
+        }
+
+        &__nav-link {
+            padding-bottom: 1rem;
+        }
+
+        &__cta-button {
+            margin-top: 0.5rem;
+        }
+    }
+}
+
+@media (max-width: 767px) {
+    .skylad-header {
+        &__top-bar-left,
+        &__top-bar-right {
+            width: 100%;
+            justify-content: center;
         }
     }
 }
 
 @media (max-width: 575px) {
     .skylad-header {
-        &__main {
-            padding: 1rem 0;
+        &__main-inner {
+            min-height: auto;
+            padding: 1rem 0 0.75rem;
+        }
+
+        &__nav-list {
+            gap: 0.75rem 1.25rem;
         }
 
         &__nav-link {
-            letter-spacing: 0.08em;
+            font-size: 0.875rem;
+            padding-bottom: 0.75rem;
         }
 
         &__cta-button {
             width: 100%;
+            justify-content: center;
         }
     }
 }

--- a/src/Resources/app/storefront/src/scss/_overrides.scss
+++ b/src/Resources/app/storefront/src/scss/_overrides.scss
@@ -34,75 +34,7 @@ a {
     }
 }
 
-// Header + footer styling inspired by Divi
-.skylad-header {
-    background: $surface-bg;
-    color: $text-color;
-    font-family: $font-family-base;
-    box-shadow: 0 16px 32px rgba($brand-dark-grey, 0.05);
-
-    a {
-        color: inherit;
-        transition: color 0.2s ease, box-shadow 0.2s ease;
-
-        &:hover,
-        &:focus {
-            color: $brand-primary;
-        }
-    }
-
-    &__top-bar {
-        background: $brand-dark-grey;
-        color: rgba($brand-primary-contrast, 0.9);
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-    }
-
-    &__top-bar-item {
-        font-weight: 500;
-        letter-spacing: 0.04em;
-
-        &--whatsapp {
-            font-weight: 600;
-        }
-    }
-
-    &__nav-link {
-        font-family: inherit;
-        font-weight: 600;
-        text-transform: uppercase;
-        letter-spacing: 0.12em;
-        transition: color 0.2s ease, box-shadow 0.2s ease;
-
-        &:hover,
-        &:focus {
-            color: $brand-primary;
-        }
-
-        &.is-active,
-        &[aria-current='page'] {
-            color: $brand-primary;
-        }
-    }
-
-    &__cta-button {
-        background: linear-gradient(135deg, lighten($brand-primary, 6%), $brand-primary-dark);
-        color: $brand-primary-contrast;
-        border: none;
-        box-shadow: 0 18px 36px rgba($brand-primary, 0.24);
-
-        &:hover,
-        &:focus {
-            background: linear-gradient(135deg, lighten($brand-primary, 12%), $brand-primary);
-            box-shadow: 0 22px 44px rgba($brand-primary, 0.28);
-        }
-    }
-
-    &__cta-icon svg {
-        fill: currentColor;
-    }
-}
-
+// Footer styling inspired by Divi
 .footer-main {
     background: $surface-muted;
     color: $text-color;

--- a/src/Resources/views/storefront/layout/header/header.html.twig
+++ b/src/Resources/views/storefront/layout/header/header.html.twig
@@ -14,27 +14,32 @@
         : topBarLinkTranslation %}
     {% set hasTopBarAddress = topBarAddress != 'skylad.header.topBar.address' and topBarAddress|trim is not empty %}
     {% set hasTopBarWhatsApp = topBarWhatsAppLabel != 'skylad.header.topBar.whatsAppLabel' and topBarWhatsAppLabel|trim is not empty %}
+    {% set hasTopBar = hasTopBarAddress or hasTopBarWhatsApp %}
 
     <header class="skylad-header">
         {% block layout_header_top_bar %}
-            {% if hasTopBarAddress or hasTopBarWhatsApp %}
+            {% if hasTopBar %}
                 <div class="skylad-header__top-bar">
                     <div class="container">
                         <div class="skylad-header__top-bar-inner">
                             {% if hasTopBarAddress %}
-                                <span class="skylad-header__top-bar-item skylad-header__top-bar-item--address">
-                                    {{ topBarAddress|sw_sanitize }}
-                                </span>
+                                <div class="skylad-header__top-bar-left">
+                                    <span class="skylad-header__top-bar-item skylad-header__top-bar-item--address">
+                                        {{ topBarAddress|sw_sanitize }}
+                                    </span>
+                                </div>
                             {% endif %}
 
                             {% if hasTopBarWhatsApp %}
-                                <a class="skylad-header__top-bar-item skylad-header__top-bar-item--whatsapp"
-                                   href="{{ topBarWhatsAppLink|striptags }}"
-                                   target="_blank"
-                                   rel="noopener noreferrer"
-                                    title="{{ topBarWhatsAppLabel|striptags }}">
-                                    {{ topBarWhatsAppLabel|sw_sanitize }}
-                                </a>
+                                <div class="skylad-header__top-bar-right">
+                                    <a class="skylad-header__top-bar-item skylad-header__top-bar-item--whatsapp"
+                                       href="{{ topBarWhatsAppLink|striptags }}"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       title="{{ topBarWhatsAppLabel|striptags }}">
+                                        {{ topBarWhatsAppLabel|sw_sanitize }}
+                                    </a>
+                                </div>
                             {% endif %}
                         </div>
                     </div>
@@ -122,7 +127,7 @@
         ? 'skylad.home.header.whatsAppLabel'|trans
         : buttonLabelTranslation %}
     <div class="skylad-header__cta">
-        <a class="skylad-header__cta-button btn"
+        <a class="skylad-header__cta-button"
            href="{{ headerWhatsAppLink|striptags }}"
            target="_blank"
            rel="noopener noreferrer"


### PR DESCRIPTION
## Summary
- restructure the header top bar markup so address and WhatsApp areas mirror the Divi two-row layout
- restyle the header SCSS to match the reference spacing, typography and hover states while providing responsive fallbacks
- drop conflicting header overrides to let the dedicated stylesheet control the look and keep footer/global helpers intact

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68c9f3bc96f883298a6dcee37d163179